### PR TITLE
Add task entities

### DIFF
--- a/backend/src/Entity/Task.php
+++ b/backend/src/Entity/Task.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\TaskStatus;
+use App\Enum\TaskOrigin;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Task
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string')]
+    private string $title;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(type: 'datetime', nullable: true)]
+    private ?\DateTimeInterface $dueAt = null;
+
+    #[ORM\Column(enumType: TaskStatus::class)]
+    private TaskStatus $status;
+
+    #[ORM\Column(enumType: TaskOrigin::class)]
+    private TaskOrigin $origin;
+
+    #[ORM\Column(type: 'guid', nullable: true)]
+    private ?string $relatedId = null;
+
+    #[ORM\ManyToOne(targetEntity: StallUnit::class)]
+    private ?StallUnit $stallUnit = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getDueAt(): ?\DateTimeInterface
+    {
+        return $this->dueAt;
+    }
+
+    public function setDueAt(?\DateTimeInterface $dueAt): self
+    {
+        $this->dueAt = $dueAt;
+        return $this;
+    }
+
+    public function getStatus(): TaskStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(TaskStatus $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getOrigin(): TaskOrigin
+    {
+        return $this->origin;
+    }
+
+    public function setOrigin(TaskOrigin $origin): self
+    {
+        $this->origin = $origin;
+        return $this;
+    }
+
+    public function getRelatedId(): ?string
+    {
+        return $this->relatedId;
+    }
+
+    public function setRelatedId(?string $relatedId): self
+    {
+        $this->relatedId = $relatedId;
+        return $this;
+    }
+
+    public function getStallUnit(): ?StallUnit
+    {
+        return $this->stallUnit;
+    }
+
+    public function setStallUnit(?StallUnit $stallUnit): self
+    {
+        $this->stallUnit = $stallUnit;
+        return $this;
+    }
+}

--- a/backend/src/Entity/TaskAssignment.php
+++ b/backend/src/Entity/TaskAssignment.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\TaskAssignmentStatus;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class TaskAssignment
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Task::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private Task $task;
+
+    #[ORM\Column(type: 'string')]
+    private string $user;
+
+    #[ORM\Column(enumType: TaskAssignmentStatus::class)]
+    private TaskAssignmentStatus $status;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTask(): Task
+    {
+        return $this->task;
+    }
+
+    public function setTask(Task $task): self
+    {
+        $this->task = $task;
+        return $this;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function setUser(string $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getStatus(): TaskAssignmentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(TaskAssignmentStatus $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/backend/src/Enum/TaskAssignmentStatus.php
+++ b/backend/src/Enum/TaskAssignmentStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum TaskAssignmentStatus: string
+{
+    case ASSIGNED = 'assigned';
+    case ACCEPTED = 'accepted';
+    case DECLINED = 'declined';
+}

--- a/backend/src/Enum/TaskOrigin.php
+++ b/backend/src/Enum/TaskOrigin.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum TaskOrigin: string
+{
+    case MANUAL = 'manual';
+    case SERVICE_BOOKING = 'serviceBooking';
+    case SPECIAL_BOOKING = 'specialBooking';
+}

--- a/backend/src/Enum/TaskStatus.php
+++ b/backend/src/Enum/TaskStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum TaskStatus: string
+{
+    case OPEN = 'open';
+    case IN_PROGRESS = 'in_progress';
+    case DONE = 'done';
+    case CANCELLED = 'cancelled';
+}


### PR DESCRIPTION
## Summary
- add Symfony Task & TaskAssignment entities
- define TaskStatus, TaskOrigin, TaskAssignmentStatus enums

## Testing
- `php -l backend/src/Entity/Task.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc05e052c8324820aee3cf77050f7