### PR TITLE
Add Symfony User entity with role enum

### DIFF
--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\UserRole;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', unique: true)]
+    private string $email;
+
+    #[ORM\Column(type: 'string')]
+    private string $passwordHash;
+
+    #[ORM\Column(enumType: UserRole::class)]
+    private UserRole $role;
+
+    #[ORM\Column(type: 'string')]
+    private string $firstName;
+
+    #[ORM\Column(type: 'string')]
+    private string $lastName;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    private ?string $phone = null;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $active;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $createdAt;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getPasswordHash(): string
+    {
+        return $this->passwordHash;
+    }
+
+    public function setPasswordHash(string $passwordHash): self
+    {
+        $this->passwordHash = $passwordHash;
+        return $this;
+    }
+
+    public function getRole(): UserRole
+    {
+        return $this->role;
+    }
+
+    public function setRole(UserRole $role): self
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): self
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): self
+    {
+        $this->lastName = $lastName;
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): self
+    {
+        $this->phone = $phone;
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): self
+    {
+        $this->active = $active;
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+}

--- a/backend/src/Enum/UserRole.php
+++ b/backend/src/Enum/UserRole.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum UserRole: string
+{
+    case ADMIN = 'admin';
+    case STAFF = 'staff';
+    case CUSTOMER = 'customer';
+}


### PR DESCRIPTION
## Summary
- add `User` entity for backend auth
- define `UserRole` enum for allowed roles

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc14e32908324acab41c1515f4496