### PR TITLE
Add React frontend with auth context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,13 @@
 # Frontend
 
 React-Frontend für Kunden, Mitarbeitende und Admins des SilentOakRanch-Portals.
+
+## Entwicklung
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Der Development-Server läuft standardmäßig unter [http://localhost:5173](http://localhost:5173).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Silent Oak Ranch</title>
+  </head>
+  <body class="min-h-screen bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "silent-oak-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,21 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import Login from './modules/auth/Login'
+import Dashboard from './modules/dashboard/Dashboard'
+import { useAuth } from './modules/auth/AuthContext'
+
+function App() {
+  const { token } = useAuth()
+
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/dashboard"
+        element={token ? <Dashboard /> : <Navigate to="/login" replace />}
+      />
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
+  )
+}
+
+export default App

--- a/frontend/src/axios.ts
+++ b/frontend/src/axios.ts
@@ -1,0 +1,16 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: '/api',
+})
+
+api.interceptors.request.use(config => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers = config.headers ?? {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export default api

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+import { AuthProvider } from './modules/auth/AuthContext'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/src/modules/auth/AuthContext.tsx
+++ b/frontend/src/modules/auth/AuthContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+import api from '../../axios'
+
+type AuthState = {
+  user: string | null
+  role: 'admin' | 'staff' | 'customer' | null
+  token: string | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<string | null>(() =>
+    localStorage.getItem('user')
+  )
+  const [role, setRole] = useState<'admin' | 'staff' | 'customer' | null>(() =>
+    (localStorage.getItem('role') as 'admin' | 'staff' | 'customer' | null) ||
+    null
+  )
+  const [token, setToken] = useState<string | null>(() =>
+    localStorage.getItem('token')
+  )
+
+  async function login(username: string, password: string) {
+    const response = await api.post('/login', { username, password })
+    const { token, role } = response.data
+    setUser(username)
+    setToken(token)
+    setRole(role)
+    localStorage.setItem('user', username)
+    localStorage.setItem('token', token)
+    localStorage.setItem('role', role)
+  }
+
+  function logout() {
+    setUser(null)
+    setToken(null)
+    setRole(null)
+    localStorage.removeItem('user')
+    localStorage.removeItem('token')
+    localStorage.removeItem('role')
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, role, token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('AuthContext not found')
+  return ctx
+}

--- a/frontend/src/modules/auth/Login.tsx
+++ b/frontend/src/modules/auth/Login.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from './AuthContext'
+
+function Login() {
+  const navigate = useNavigate()
+  const { login } = useAuth()
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      await login(username, password)
+      navigate('/dashboard')
+    } catch (err) {
+      setError('Invalid credentials')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center h-screen bg-gray-200">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80">
+        <h1 className="text-2xl mb-4">Login</h1>
+        {error && <p className="text-red-500 mb-2">{error}</p>}
+        <input
+          className="border w-full p-2 mb-2"
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+        <input
+          className="border w-full p-2 mb-4"
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 w-full">Login</button>
+      </form>
+    </div>
+  )
+}
+
+export default Login

--- a/frontend/src/modules/dashboard/Dashboard.tsx
+++ b/frontend/src/modules/dashboard/Dashboard.tsx
@@ -1,0 +1,46 @@
+import { useAuth } from '../auth/AuthContext'
+
+function AdminView() {
+  return <div className="p-4">Admin Dashboard</div>
+}
+
+function StaffView() {
+  return <div className="p-4">Staff Dashboard</div>
+}
+
+function CustomerView() {
+  return <div className="p-4">Customer Dashboard</div>
+}
+
+function Dashboard() {
+  const { role, user, logout } = useAuth()
+
+  let content: JSX.Element | null = null
+  switch (role) {
+    case 'admin':
+      content = <AdminView />
+      break
+    case 'staff':
+      content = <StaffView />
+      break
+    case 'customer':
+      content = <CustomerView />
+      break
+    default:
+      content = null
+  }
+
+  return (
+    <div className="min-h-screen">
+      <header className="bg-gray-800 text-white p-4 flex justify-between">
+        <span>Logged in as {user}</span>
+        <button onClick={logout} className="text-sm underline">
+          Logout
+        </button>
+      </header>
+      {content}
+    </div>
+  )
+}
+
+export default Dashboard

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "../shared"}]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+})


### PR DESCRIPTION
## Summary
- create React-based frontend using Vite and TailwindCSS
- implement simple auth context storing JWT and role
- create login page and role-dependent dashboard routes
- configure axios instance with auth header
- document frontend dev steps

## Testing
- `npm install --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_e_686fc4aa4bcc8324963156b869e2ba55