### PR TITLE
Configure JWT login in Symfony backend

### DIFF
--- a/backend/config/packages/lexik_jwt_authentication.yaml
+++ b/backend/config/packages/lexik_jwt_authentication.yaml
@@ -2,3 +2,5 @@ lexik_jwt_authentication:
     secret_key: '%env(resolve:JWT_SECRET_KEY)%'
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
+    token_ttl: 3600
+    user_identity_field: email

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -4,14 +4,26 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            lazy: true
-            provider: users_in_memory
+            pattern: ^/api
+            stateless: true
+            provider: app_user_provider
+            json_login:
+                check_path: /api/login
+                username_path: email
+                password_path: password
+                user_identifier_key: email
+                success_handler: lexik_jwt_authentication.handler.authentication_success
+                failure_handler: lexik_jwt_authentication.handler.authentication_failure
+            jwt: ~
 
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
@@ -22,8 +34,8 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/api/login, roles: PUBLIC_ACCESS }
+        - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
 
 when@test:
     security:

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -3,10 +3,12 @@
 namespace App\Entity;
 
 use App\Enum\UserRole;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-class User
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -17,7 +19,10 @@ class User
     private string $email;
 
     #[ORM\Column(type: 'string')]
-    private string $passwordHash;
+    private string $password;
+
+    #[ORM\Column(type: 'json')]
+    private array $roles = [];
 
     #[ORM\Column(enumType: UserRole::class)]
     private UserRole $role;
@@ -53,15 +58,39 @@ class User
         return $this;
     }
 
-    public function getPasswordHash(): string
+    public function getPassword(): string
     {
-        return $this->passwordHash;
+        return $this->password;
     }
 
-    public function setPasswordHash(string $passwordHash): self
+    public function setPassword(string $password): self
     {
-        $this->passwordHash = $passwordHash;
+        $this->password = $password;
         return $this;
+    }
+
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        $roles[] = 'ROLE_USER';
+
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->email;
+    }
+
+    public function eraseCredentials(): void
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
     }
 
     public function getRole(): UserRole


### PR DESCRIPTION
## Summary
- implement `UserInterface` and password-based login fields in `User` entity
- configure JWT login in `security.yaml`
- add LexikJWT settings

## Testing
- `php -l backend/src/Entity/User.php`
- *(YAML syntax could not be fully validated without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872120ea3788324965ef475d60c4e5b