### PR TITLE
Implement /api/me endpoint

### DIFF
--- a/backend/src/Controller/MeController.php
+++ b/backend/src/Controller/MeController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Security;
+
+class MeController extends AbstractController
+{
+    #[Route('/api/me', name: 'api_me', methods: ['GET'])]
+    public function __invoke(Security $security): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $security->getUser();
+
+        if (!$user instanceof User) {
+            return $this->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $data = [
+            'id' => $user->getId(),
+            'email' => $user->getEmail(),
+            'roles' => $user->getRoles(),
+        ];
+
+        if (method_exists($user, 'getFirstName')) {
+            $data['firstName'] = $user->getFirstName();
+        }
+        if (method_exists($user, 'getLastName')) {
+            $data['lastName'] = $user->getLastName();
+        }
+        if (method_exists($user, 'getAssignedStallUnit')) {
+            $stallUnit = $user->getAssignedStallUnit();
+            if ($stallUnit) {
+                $label = null;
+                if (method_exists($stallUnit, 'getLabel')) {
+                    $label = $stallUnit->getLabel();
+                } elseif (method_exists($stallUnit, 'getName')) {
+                    $label = $stallUnit->getName();
+                }
+                $data['assignedStallUnit'] = [
+                    'id' => $stallUnit->getId(),
+                    'label' => $label,
+                ];
+            }
+        }
+
+        return $this->json($data);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MeController` with secured `/api/me` route for retrieving the logged in user

## Testing
- `php -l backend/src/Controller/MeController.php`
- `composer install --no-interaction` *(fails: ext-sodium missing)*


------
https://chatgpt.com/codex/tasks/task_e_6872137004f0832483e12bd48270c725