### PR TITLE
Handle /me failure in login

### DIFF
--- a/frontend/src/modules/auth/AuthContext.tsx
+++ b/frontend/src/modules/auth/AuthContext.tsx
@@ -27,17 +27,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   async function login(username: string, password: string) {
     const response = await api.post('/login', { username, password })
-    const { token, role } = response.data
-    setToken(token)
-    setRole(role)
-    localStorage.setItem('token', token)
-    localStorage.setItem('role', role)
+    const { token: newToken, role: newRole } = response.data
 
-    const me = await api.get('/me', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    setUser(me.data as UserInfo)
-    localStorage.setItem('user', JSON.stringify(me.data))
+    try {
+      const me = await api.get('/me', {
+        headers: { Authorization: `Bearer ${newToken}` },
+      })
+
+      setUser(me.data as UserInfo)
+      setToken(newToken)
+      setRole(newRole)
+      localStorage.setItem('token', newToken)
+      localStorage.setItem('role', newRole)
+      localStorage.setItem('user', JSON.stringify(me.data))
+    } catch (err) {
+      setToken(null)
+      setRole(null)
+      localStorage.removeItem('token')
+      localStorage.removeItem('role')
+      throw err
+    }
   }
 
   function logout() {


### PR DESCRIPTION
## Summary
- guard /me request inside `login`
- clear token and role if `/me` fails

## Testing
- `npm run build` *(fails: cannot find `shared/tsconfig.json`)*
- `npx tsc -p tsconfig.json` *(fails: file `/workspace/SilentOakRanch/shared` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873428be0448324818a64929c6949c7