### PR TITLE
Fix loading reset on missing token

### DIFF
--- a/frontend/src/modules/auth/useUser.ts
+++ b/frontend/src/modules/auth/useUser.ts
@@ -23,6 +23,7 @@ export function useUser() {
   useEffect(() => {
     if (!token) {
       setUser(null)
+      setLoading(false)
       return
     }
     setLoading(true)


### PR DESCRIPTION
## Summary
- set loading state to false when no auth token so logout doesn't hang

## Testing
- `npm run build` *(fails: missing shared tsconfig)*
- `composer install --ignore-platform-req=ext-sodium --no-scripts`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687343f41128832498c87625486a67ec