### PR TITLE
Add booking entity and API

### DIFF
--- a/backend/config/packages/lexik_jwt_authentication.yaml
+++ b/backend/config/packages/lexik_jwt_authentication.yaml
@@ -3,4 +3,4 @@ lexik_jwt_authentication:
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
     token_ttl: 3600
-    user_identity_field: email
+    user_id_claim: email

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -20,7 +20,6 @@ security:
                 check_path: /api/login
                 username_path: email
                 password_path: password
-                user_identifier_key: email
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
             jwt: ~

--- a/backend/migrations/Version20240713060000.php
+++ b/backend/migrations/Version20240713060000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240713060000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create booking table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE booking (id INT AUTO_INCREMENT NOT NULL, stall_unit_id INT NOT NULL, start_date DATETIME NOT NULL, end_date DATETIME NOT NULL, horse_id INT DEFAULT NULL, user VARCHAR(255) NOT NULL, status VARCHAR(255) NOT NULL, INDEX IDX_BOOKING_STALL_UNIT (stall_unit_id), INDEX IDX_BOOKING_HORSE (horse_id), PRIMARY KEY(id))");
+        $this->addSql("ALTER TABLE booking ADD CONSTRAINT FK_BOOKING_STALL_UNIT FOREIGN KEY (stall_unit_id) REFERENCES stall_unit (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
+        $this->addSql("ALTER TABLE booking ADD CONSTRAINT FK_BOOKING_HORSE FOREIGN KEY (horse_id) REFERENCES horse (id) NOT DEFERRABLE INITIALLY IMMEDIATE");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE booking');
+    }
+}

--- a/backend/src/Controller/BookingController.php
+++ b/backend/src/Controller/BookingController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Booking;
+use App\Entity\Horse;
+use App\Repository\BookingRepository;
+use App\Repository\StallUnitRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class BookingController extends AbstractController
+{
+    #[Route('/api/bookings', name: 'api_create_booking', methods: ['POST'])]
+    public function __invoke(
+        Request $request,
+        StallUnitRepository $stallUnitRepository,
+        BookingRepository $bookingRepository,
+        EntityManagerInterface $em,
+        Security $security
+    ): JsonResponse {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['stallUnitId'], $data['startDate'], $data['endDate'])) {
+            return $this->json(['message' => 'Invalid payload'], 400);
+        }
+
+        $stallUnit = $stallUnitRepository->find($data['stallUnitId']);
+        if (!$stallUnit) {
+            return $this->json(['message' => 'StallUnit not found'], 404);
+        }
+
+        $start = new \DateTimeImmutable($data['startDate']);
+        $end = new \DateTimeImmutable($data['endDate']);
+
+        if ($bookingRepository->hasOverlap($stallUnit, $start, $end)) {
+            return $this->json(['message' => 'Booking overlaps existing booking'], 400);
+        }
+
+        $booking = new Booking();
+        $booking->setStallUnit($stallUnit)
+            ->setStartDate($start)
+            ->setEndDate($end);
+
+        if (isset($data['horseId'])) {
+            /** @var Horse|null $horse */
+            $horse = $em->getRepository(Horse::class)->find($data['horseId']);
+            if (!$horse) {
+                return $this->json(['message' => 'Horse not found'], 404);
+            }
+            $booking->setHorse($horse);
+        }
+
+        $user = $security->getUser();
+        if ($user && method_exists($user, 'getEmail')) {
+            $booking->setUser($user->getEmail());
+        } else {
+            return $this->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $em->persist($booking);
+        $em->flush();
+
+        $label = method_exists($stallUnit, 'getLabel') ? $stallUnit->getLabel() : $stallUnit->getName();
+
+        return $this->json([
+            'id' => $booking->getId(),
+            'status' => $booking->getStatus()->name,
+            'stallUnit' => [
+                'id' => $stallUnit->getId(),
+                'label' => $label,
+            ],
+            'startDate' => $start->format('c'),
+            'endDate' => $end->format('c'),
+        ]);
+    }
+}

--- a/backend/src/Entity/Booking.php
+++ b/backend/src/Entity/Booking.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\BookingStatus;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: 'App\\Repository\\BookingRepository')]
+class Booking
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: StallUnit::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private StallUnit $stallUnit;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $startDate;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $endDate;
+
+    #[ORM\ManyToOne(targetEntity: Horse::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?Horse $horse = null;
+
+    #[ORM\Column(type: 'string')]
+    private string $user;
+
+    #[ORM\Column(enumType: BookingStatus::class)]
+    private BookingStatus $status = BookingStatus::PENDING;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getStallUnit(): StallUnit
+    {
+        return $this->stallUnit;
+    }
+
+    public function setStallUnit(StallUnit $stallUnit): self
+    {
+        $this->stallUnit = $stallUnit;
+        return $this;
+    }
+
+    public function getStartDate(): \DateTimeInterface
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(\DateTimeInterface $startDate): self
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    public function getEndDate(): \DateTimeInterface
+    {
+        return $this->endDate;
+    }
+
+    public function setEndDate(\DateTimeInterface $endDate): self
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+
+    public function getHorse(): ?Horse
+    {
+        return $this->horse;
+    }
+
+    public function setHorse(?Horse $horse): self
+    {
+        $this->horse = $horse;
+        return $this;
+    }
+
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    public function setUser(string $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getStatus(): BookingStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(BookingStatus $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+}

--- a/backend/src/Enum/BookingStatus.php
+++ b/backend/src/Enum/BookingStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum BookingStatus: string
+{
+    case PENDING = 'pending';
+    case CONFIRMED = 'confirmed';
+    case CANCELLED = 'cancelled';
+}

--- a/backend/src/Repository/BookingRepository.php
+++ b/backend/src/Repository/BookingRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Booking;
+use App\Entity\StallUnit;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Booking>
+ */
+class BookingRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Booking::class);
+    }
+
+    public function hasOverlap(StallUnit $stallUnit, \DateTimeInterface $start, \DateTimeInterface $end): bool
+    {
+        $qb = $this->createQueryBuilder('b');
+        $qb->select('count(b.id)')
+            ->where('b.stallUnit = :stallUnit')
+            ->andWhere('b.startDate < :end')
+            ->andWhere('b.endDate > :start')
+            ->setParameter('stallUnit', $stallUnit)
+            ->setParameter('start', $start)
+            ->setParameter('end', $end);
+
+        return (int) $qb->getQuery()->getSingleScalarResult() > 0;
+    }
+}

--- a/backend/tests/BookingControllerTest.php
+++ b/backend/tests/BookingControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Tests;
+
+use App\Controller\BookingController;
+use App\Entity\Booking;
+use App\Entity\StallUnit;
+use App\Entity\User;
+use App\Enum\StallUnitStatus;
+use App\Enum\StallUnitType;
+use App\Enum\UserRole;
+use App\Repository\BookingRepository;
+use App\Repository\StallUnitRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class BookingControllerTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private BookingRepository $bookingRepository;
+    private StallUnitRepository $stallUnitRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->bookingRepository = $container->get(BookingRepository::class);
+        $this->stallUnitRepository = $container->get(StallUnitRepository::class);
+
+        $tool = new SchemaTool($this->em);
+        $tool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $tool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    private function createUser(): User
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('pw');
+        $user->setRoles([]);
+        $user->setRole(UserRole::CUSTOMER);
+        $user->setFirstName('A');
+        $user->setLastName('B');
+        $user->setActive(true);
+        $user->setCreatedAt(new \DateTimeImmutable());
+        return $user;
+    }
+
+    private function createStallUnit(): StallUnit
+    {
+        $stall = new StallUnit();
+        $stall->setName('Box 1');
+        $stall->setType(StallUnitType::BOX);
+        $stall->setArea('A');
+        $stall->setStatus(StallUnitStatus::FREE);
+        $this->em->persist($stall);
+        $this->em->flush();
+        return $stall;
+    }
+
+    public function testCreateBookingSuccess(): void
+    {
+        $stall = $this->createStallUnit();
+        $user = $this->createUser();
+
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $controller = static::getContainer()->get(BookingController::class);
+
+        $request = new Request([], [], [], [], [], [], json_encode([
+            'stallUnitId' => $stall->getId(),
+            'startDate' => '2024-01-01T00:00:00Z',
+            'endDate' => '2024-01-10T00:00:00Z',
+        ]));
+
+        $response = $controller->__invoke($request, $this->stallUnitRepository, $this->bookingRepository, $this->em, $security);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('PENDING', $data['status']);
+        $this->assertNotNull($data['id']);
+    }
+
+    public function testOverlapRejected(): void
+    {
+        $stall = $this->createStallUnit();
+        $user = $this->createUser();
+
+        $booking = new Booking();
+        $booking->setStallUnit($stall)
+            ->setStartDate(new \DateTimeImmutable('2024-01-05'))
+            ->setEndDate(new \DateTimeImmutable('2024-01-15'))
+            ->setUser($user->getEmail());
+        $this->em->persist($booking);
+        $this->em->flush();
+
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $controller = static::getContainer()->get(BookingController::class);
+        $request = new Request([], [], [], [], [], [], json_encode([
+            'stallUnitId' => $stall->getId(),
+            'startDate' => '2024-01-10T00:00:00Z',
+            'endDate' => '2024-01-20T00:00:00Z',
+        ]));
+
+        $response = $controller->__invoke($request, $this->stallUnitRepository, $this->bookingRepository, $this->em, $security);
+        $this->assertSame(400, $response->getStatusCode());
+    }
+}

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -8,6 +8,10 @@ if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
 
+// Use SQLite in-memory database for tests
+$_ENV['DATABASE_URL'] = 'sqlite:///:memory:';
+$_SERVER['DATABASE_URL'] = 'sqlite:///:memory:';
+
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 }


### PR DESCRIPTION
## Summary
- add `Booking` entity and `BookingStatus` enum
- add repository with overlap detection
- expose POST `/api/bookings` controller
- provide Doctrine migration
- use SQLite for tests and add functional tests
- adjust security bundle configs for current Symfony version

## Testing
- `./vendor/bin/phpunit tests/BookingControllerTest.php`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68734bd9a73083248bbf20b1598eda72