### PR TITLE
Add my invoices endpoint

### DIFF
--- a/backend/src/Controller/MyInvoicesController.php
+++ b/backend/src/Controller/MyInvoicesController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\InvoiceRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class MyInvoicesController extends AbstractController
+{
+    #[Route('/api/my/invoices', name: 'api_my_invoices', methods: ['GET'])]
+    public function __invoke(InvoiceRepository $invoiceRepository, Security $security): JsonResponse
+    {
+        $user = $security->getUser();
+
+        if (!$user) {
+            return $this->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $invoices = $invoiceRepository->findByUser($user->getEmail());
+        $data = [];
+
+        foreach ($invoices as $invoice) {
+            $number = method_exists($invoice, 'getNumber') ? $invoice->getNumber() : '';
+            $data[] = [
+                'id' => $invoice->getId(),
+                'number' => $number,
+                'period' => $invoice->getPeriod(),
+                'amount' => $invoice->getTotal(),
+                'status' => $invoice->getStatus()->name,
+                'downloadUrl' => '/storage/invoices/' . $number . '.pdf',
+            ];
+        }
+
+        return $this->json($data);
+    }
+}

--- a/backend/src/Entity/Invoice.php
+++ b/backend/src/Entity/Invoice.php
@@ -16,6 +16,9 @@ class Invoice
     #[ORM\Column(type: 'string')]
     private string $user;
 
+    #[ORM\Column(type: 'string', unique: true)]
+    private string $number;
+
     #[ORM\Column(type: 'string')]
     private string $period;
 
@@ -41,6 +44,17 @@ class Invoice
     public function setUser(string $user): self
     {
         $this->user = $user;
+        return $this;
+    }
+
+    public function getNumber(): string
+    {
+        return $this->number;
+    }
+
+    public function setNumber(string $number): self
+    {
+        $this->number = $number;
         return $this;
     }
 

--- a/backend/src/Repository/InvoiceRepository.php
+++ b/backend/src/Repository/InvoiceRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Invoice;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Invoice>
+ */
+class InvoiceRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Invoice::class);
+    }
+
+    /**
+     * @return Invoice[]
+     */
+    public function findByUser(string $email): array
+    {
+        return $this->createQueryBuilder('i')
+            ->where('i.user = :email')
+            ->setParameter('email', $email)
+            ->orderBy('i.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/backend/tests/MyInvoicesControllerTest.php
+++ b/backend/tests/MyInvoicesControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Tests;
+
+use App\Controller\MyInvoicesController;
+use App\Entity\Invoice;
+use App\Entity\User;
+use App\Enum\InvoiceStatus;
+use App\Enum\UserRole;
+use App\Repository\InvoiceRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class MyInvoicesControllerTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private InvoiceRepository $invoiceRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->invoiceRepository = $container->get(InvoiceRepository::class);
+
+        $tool = new SchemaTool($this->em);
+        $tool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $tool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    private function createUser(): User
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('pw');
+        $user->setRoles([]);
+        $user->setRole(UserRole::CUSTOMER);
+        $user->setFirstName('A');
+        $user->setLastName('B');
+        $user->setActive(true);
+        $user->setCreatedAt(new \DateTimeImmutable());
+        return $user;
+    }
+
+    public function testMyInvoices(): void
+    {
+        $user = $this->createUser();
+
+        $invoice = new Invoice();
+        $invoice->setUser($user->getEmail());
+        $invoice->setNumber('INV-001');
+        $invoice->setPeriod('2024-01');
+        $invoice->setCreatedAt(new \DateTimeImmutable());
+        $invoice->setStatus(InvoiceStatus::OPEN);
+        $invoice->setTotal('100.00');
+        $this->em->persist($invoice);
+        $this->em->flush();
+
+        $security = $this->createMock(Security::class);
+        $security->method('getUser')->willReturn($user);
+
+        $controller = static::getContainer()->get(MyInvoicesController::class);
+
+        $response = $controller->__invoke($this->invoiceRepository, $security);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $data);
+        $this->assertSame('INV-001', $data[0]['number']);
+        $this->assertSame('OPEN', $data[0]['status']);
+        $this->assertSame('/storage/invoices/INV-001.pdf', $data[0]['downloadUrl']);
+    }
+}


### PR DESCRIPTION
## Summary
- support storing invoice numbers
- add an InvoiceRepository with a helper to fetch invoices for the authenticated user
- expose `GET /api/my/invoices`
- add functional test for invoice listing

## Testing
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_687352a292988324befe918c162af96b