### PR TITLE
Add price to Booking

### DIFF
--- a/backend/migrations/Version20240713071000.php
+++ b/backend/migrations/Version20240713071000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240713071000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add price column to booking table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE booking ADD price NUMERIC(10, 2) DEFAULT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE booking DROP price");
+    }
+}

--- a/backend/src/Entity/Booking.php
+++ b/backend/src/Entity/Booking.php
@@ -49,6 +49,9 @@ class Booking
     #[ORM\Column(type: 'boolean')]
     private bool $isConfirmed = false;
 
+    #[ORM\Column(type: 'decimal', precision: 10, scale: 2, nullable: true)]
+    private ?string $price = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -172,6 +175,17 @@ class Booking
     public function setIsConfirmed(bool $isConfirmed): self
     {
         $this->isConfirmed = $isConfirmed;
+        return $this;
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?string $price): self
+    {
+        $this->price = $price;
         return $this;
     }
 }

--- a/backend/tests/BookingControllerTest.php
+++ b/backend/tests/BookingControllerTest.php
@@ -120,12 +120,16 @@ class BookingControllerTest extends KernelTestCase
             ->setStartDate(new \DateTimeImmutable('2024-01-05'))
             ->setEndDate(new \DateTimeImmutable('2024-01-15'))
             ->setUser($user->getEmail())
+            ->setPrice('50.00')
             ->setType(BookingType::OTHER)
             ->setLabel('Overlap')
             ->setDateFrom(new \DateTimeImmutable('2024-01-05'))
             ->setDateTo(new \DateTimeImmutable('2024-01-15'));
         $this->em->persist($booking);
         $this->em->flush();
+
+        $stored = $this->bookingRepository->find($booking->getId());
+        $this->assertSame('50.00', $stored->getPrice());
 
         $security = $this->createMock(Security::class);
         $security->method('getUser')->willReturn($user);

--- a/backend/tests/MyBookingsControllerTest.php
+++ b/backend/tests/MyBookingsControllerTest.php
@@ -92,12 +92,16 @@ class MyBookingsControllerTest extends KernelTestCase
             ->setEndDate(new \DateTimeImmutable('2024-01-10'))
             ->setUser($user->getEmail())
             ->setHorse($horse)
+            ->setPrice('12.34')
             ->setType(BookingType::OTHER)
             ->setLabel('test')
             ->setDateFrom(new \DateTimeImmutable('2024-01-01'))
             ->setDateTo(new \DateTimeImmutable('2024-01-10'));
         $this->em->persist($booking);
         $this->em->flush();
+
+        $stored = $this->bookingRepository->find($booking->getId());
+        $this->assertSame('12.34', $stored->getPrice());
 
         $security = $this->createMock(Security::class);
         $security->method('getUser')->willReturn($user);


### PR DESCRIPTION
## Summary
- add price field in Booking entity
- create migration for Booking.price
- cover price in controller tests

## Testing
- `composer install --no-interaction --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6873b441e070832484d914c8ffc81dcb