### PR TITLE
Add default flag to pricing rules

### DIFF
--- a/backend/migrations/Version20240713072000.php
+++ b/backend/migrations/Version20240713072000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240713072000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_default column to pricing_rule table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE pricing_rule ADD is_default BOOLEAN NOT NULL DEFAULT FALSE");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE pricing_rule DROP is_default");
+    }
+}

--- a/backend/src/Entity/PricingRule.php
+++ b/backend/src/Entity/PricingRule.php
@@ -6,7 +6,9 @@ use App\Enum\PricingRuleType;
 use App\Enum\PricingUnit;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+use App\Repository\PricingRuleRepository;
+
+#[ORM\Entity(repositoryClass: PricingRuleRepository::class)]
 class PricingRule
 {
     #[ORM\Id]
@@ -37,6 +39,9 @@ class PricingRule
 
     #[ORM\Column(type: 'boolean')]
     private bool $requiresSubscription;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $isDefault = false;
 
     public function getId(): ?int
     {
@@ -128,6 +133,17 @@ class PricingRule
     public function setRequiresSubscription(bool $requiresSubscription): self
     {
         $this->requiresSubscription = $requiresSubscription;
+        return $this;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function setIsDefault(bool $isDefault): self
+    {
+        $this->isDefault = $isDefault;
         return $this;
     }
 }

--- a/backend/src/Repository/PricingRuleRepository.php
+++ b/backend/src/Repository/PricingRuleRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PricingRule;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PricingRule>
+ */
+class PricingRuleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PricingRule::class);
+    }
+
+    /**
+     * @return PricingRule[]
+     */
+    public function findDefaults(): array
+    {
+        return $this->createQueryBuilder('p')
+            ->where('p.isDefault = true')
+            ->getQuery()
+            ->getResult();
+    }
+}


### PR DESCRIPTION
## Summary
- allow setting a pricing rule as default
- expose repository for pricing rules
- add migration for new column

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6873b8903ed08324bf4044fab1ca4c44