### PR TITLE
Add default pricing rule lookup

### DIFF
--- a/backend/src/Repository/PricingRuleRepository.php
+++ b/backend/src/Repository/PricingRuleRepository.php
@@ -3,6 +3,8 @@
 namespace App\Repository;
 
 use App\Entity\PricingRule;
+use App\Enum\BookingType;
+use App\Enum\PricingRuleType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -25,5 +27,24 @@ class PricingRuleRepository extends ServiceEntityRepository
             ->where('p.isDefault = true')
             ->getQuery()
             ->getResult();
+    }
+
+    public function findDefault(BookingType $type, \DateTimeInterface $dateFrom): ?PricingRule
+    {
+        $ruleType = PricingRuleType::tryFrom($type->value);
+        if (null === $ruleType) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('p')
+            ->where('p.type = :type')
+            ->andWhere('p.isDefault = true')
+            ->andWhere('(p.activeFrom IS NULL OR p.activeFrom <= :date)')
+            ->andWhere('(p.activeTo IS NULL OR p.activeTo >= :date)')
+            ->setParameter('type', $ruleType)
+            ->setParameter('date', $dateFrom)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 }


### PR DESCRIPTION
## Summary
- extend PricingRuleRepository with a findDefault method
- map BookingType to PricingRuleType for rule lookup

## Testing
- `composer install --no-interaction --ignore-platform-req=ext-sodium`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6873c06d8ddc83249d7c6b7c8ad2fa3c