### PR TITLE
Add Subscription entity and enum

### DIFF
--- a/backend/src/Entity/Subscription.php
+++ b/backend/src/Entity/Subscription.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Entity;
+
+use App\Enum\BookingType;
+use App\Enum\SubscriptionStatus;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Subscription
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $user;
+
+    #[ORM\ManyToOne(targetEntity: Horse::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?Horse $horse = null;
+
+    #[ORM\Column(enumType: BookingType::class)]
+    private BookingType $type;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $startsAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $endsAt = null;
+
+    #[ORM\Column(enumType: SubscriptionStatus::class)]
+    private SubscriptionStatus $status = SubscriptionStatus::ACTIVE;
+
+    #[ORM\ManyToOne(targetEntity: PricingRule::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private PricingRule $pricingRule;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $autoRenew = true;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getHorse(): ?Horse
+    {
+        return $this->horse;
+    }
+
+    public function setHorse(?Horse $horse): self
+    {
+        $this->horse = $horse;
+        return $this;
+    }
+
+    public function getType(): BookingType
+    {
+        return $this->type;
+    }
+
+    public function setType(BookingType $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getStartsAt(): \DateTimeImmutable
+    {
+        return $this->startsAt;
+    }
+
+    public function setStartsAt(\DateTimeImmutable $startsAt): self
+    {
+        $this->startsAt = $startsAt;
+        return $this;
+    }
+
+    public function getEndsAt(): ?\DateTimeImmutable
+    {
+        return $this->endsAt;
+    }
+
+    public function setEndsAt(?\DateTimeImmutable $endsAt): self
+    {
+        $this->endsAt = $endsAt;
+        return $this;
+    }
+
+    public function getStatus(): SubscriptionStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(SubscriptionStatus $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function getPricingRule(): PricingRule
+    {
+        return $this->pricingRule;
+    }
+
+    public function setPricingRule(PricingRule $pricingRule): self
+    {
+        $this->pricingRule = $pricingRule;
+        return $this;
+    }
+
+    public function isAutoRenew(): bool
+    {
+        return $this->autoRenew;
+    }
+
+    public function setAutoRenew(bool $autoRenew): self
+    {
+        $this->autoRenew = $autoRenew;
+        return $this;
+    }
+}

--- a/backend/src/Enum/SubscriptionStatus.php
+++ b/backend/src/Enum/SubscriptionStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum SubscriptionStatus: string
+{
+    case ACTIVE = 'active';
+    case CANCELLED = 'cancelled';
+    case EXPIRED = 'expired';
+}


### PR DESCRIPTION
## Summary
- add `Subscription` entity to manage user subscriptions
- add `SubscriptionStatus` enum for subscription lifecycle states

## Testing
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873d5ca54f88324a1499cc1a419aafb