### PR TITLE
Switch to SQLite

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -26,7 +26,8 @@ APP_SECRET=
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
-DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+# DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 ###< doctrine/doctrine-bundle ###
 
 ###> lexik/jwt-authentication-bundle ###

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,15 @@
 # Backend
 
 Symfony-API für Stallverwaltung, Buchungen, Rechnungen und Authentifizierung.
+
+## Datenbank
+
+Standardmäßig wird eine SQLite-Datenbank verwendet. Die Verbindungszeichenfolge
+ist in `.env` hinterlegt und lautet:
+
+```text
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
+```
+
+Die Datei `var/data.db` befindet sich im Projektverzeichnis und wird
+automatisch angelegt, falls sie nicht existiert.


### PR DESCRIPTION
## Summary
- use sqlite database url by default
- document location of `var/data.db`

## Testing
- `composer install --prefer-dist --no-interaction --ignore-platform-req=ext-sodium`
- `./vendor/bin/phpunit --do-not-cache-result`

------
https://chatgpt.com/codex/tasks/task_e_6873e06f2e608324806aec815bd2c97e