### PR TITLE
Add subscription processing command

### DIFF
--- a/backend/src/Command/ProcessSubscriptionsCommand.php
+++ b/backend/src/Command/ProcessSubscriptionsCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Invoice;
+use App\Entity\InvoiceItem;
+use App\Enum\InvoiceStatus;
+use App\Enum\SubscriptionInterval;
+use App\Repository\InvoiceRepository;
+use App\Repository\SubscriptionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'ranch:process-subscriptions',
+    description: 'Processes due subscriptions and creates invoice items.'
+)]
+class ProcessSubscriptionsCommand extends Command
+{
+    public function __construct(
+        private readonly SubscriptionRepository $subscriptionRepository,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly EntityManagerInterface $em
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $now = new \DateTimeImmutable();
+        $subscriptions = $this->subscriptionRepository->findDueSubscriptions($now);
+        $processed = 0;
+
+        foreach ($subscriptions as $subscription) {
+            $user = $subscription->getUser();
+            $period = $subscription->getNextDue()->format('Y-m');
+
+            $invoice = $this->invoiceRepository->findOneBy([
+                'user' => $user->getEmail(),
+                'period' => $period,
+            ]);
+
+            if (!$invoice) {
+                $invoice = new Invoice();
+                $invoice->setUser($user->getEmail());
+                $invoice->setNumber(uniqid('INV-'));
+                $invoice->setPeriod($period);
+                $invoice->setCreatedAt(new \DateTimeImmutable());
+                $invoice->setStatus(InvoiceStatus::OPEN);
+                $invoice->setTotal('0.00');
+                $this->em->persist($invoice);
+            }
+
+            $itemRepo = $this->em->getRepository(InvoiceItem::class);
+            $existing = $itemRepo->findOneBy([
+                'invoice' => $invoice,
+                'label' => $subscription->getTitle(),
+            ]);
+
+            if (!$existing) {
+                $item = new InvoiceItem();
+                $item->setInvoice($invoice);
+                $item->setLabel($subscription->getTitle());
+                $item->setAmount($subscription->getAmount());
+                $this->em->persist($item);
+
+                $newTotal = ((float) $invoice->getTotal()) + (float) $subscription->getAmount();
+                $invoice->setTotal(number_format($newTotal, 2, '.', ''));
+            }
+
+            $next = $this->nextDueDate($subscription->getNextDue(), $subscription->getInterval());
+            $subscription->setNextDue($next);
+            $this->em->persist($subscription);
+
+            $processed++;
+        }
+
+        if ($processed > 0) {
+            $this->em->flush();
+        }
+
+        $output->writeln(sprintf('%d subscriptions processed.', $processed));
+
+        return Command::SUCCESS;
+    }
+
+    private function nextDueDate(\DateTimeImmutable $current, SubscriptionInterval $interval): \DateTimeImmutable
+    {
+        return match ($interval) {
+            SubscriptionInterval::DAILY => $current->add(new \DateInterval('P1D')),
+            SubscriptionInterval::WEEKLY => $current->add(new \DateInterval('P1W')),
+            SubscriptionInterval::MONTHLY => $current->add(new \DateInterval('P1M')),
+        };
+    }
+}

--- a/backend/tests/ProcessSubscriptionsCommandTest.php
+++ b/backend/tests/ProcessSubscriptionsCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Tests;
+
+use App\Command\ProcessSubscriptionsCommand;
+use App\Entity\InvoiceItem;
+use App\Entity\Subscription;
+use App\Entity\User;
+use App\Enum\SubscriptionInterval;
+use App\Enum\UserRole;
+use App\Repository\InvoiceRepository;
+use App\Repository\SubscriptionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ProcessSubscriptionsCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private SubscriptionRepository $subscriptionRepository;
+    private InvoiceRepository $invoiceRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->subscriptionRepository = $container->get(SubscriptionRepository::class);
+        $this->invoiceRepository = $container->get(InvoiceRepository::class);
+
+        $tool = new SchemaTool($this->em);
+        $tool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $tool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    private function createUser(): User
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('pw');
+        $user->setRoles([]);
+        $user->setRole(UserRole::CUSTOMER);
+        $user->setFirstName('A');
+        $user->setLastName('B');
+        $user->setActive(true);
+        $user->setCreatedAt(new \DateTimeImmutable());
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+
+    public function testProcessSubscriptions(): void
+    {
+        $user = $this->createUser();
+
+        $subscription = new Subscription();
+        $subscription->setUser($user)
+            ->setTitle('Boarding')
+            ->setAmount('50.00')
+            ->setStartsAt(new \DateTimeImmutable('2024-01-01'))
+            ->setNextDue(new \DateTimeImmutable('2024-01-01'))
+            ->setInterval(SubscriptionInterval::MONTHLY)
+            ->setActive(true)
+            ->setAutoRenew(true);
+        $this->em->persist($subscription);
+        $this->em->flush();
+
+        $application = new Application(self::$kernel);
+        $command = self::getContainer()->get(ProcessSubscriptionsCommand::class);
+        $application->add($command);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('1 subscriptions processed', $output);
+
+        $invoices = $this->invoiceRepository->findByUser($user->getEmail());
+        $this->assertCount(1, $invoices);
+        $invoice = $invoices[0];
+        $items = $this->em->getRepository(InvoiceItem::class)->findBy(['invoice' => $invoice]);
+        $this->assertCount(1, $items);
+        $this->assertSame('Boarding', $items[0]->getLabel());
+        $this->assertSame('50.00', $invoice->getTotal());
+
+        $expectedNextDue = (new \DateTimeImmutable('2024-01-01'))->add(new \DateInterval('P1M'));
+        $this->assertSame($expectedNextDue->format('Y-m-d'), $subscription->getNextDue()->format('Y-m-d'));
+    }
+}


### PR DESCRIPTION
## Summary
- create `ProcessSubscriptionsCommand` to bill subscriptions
- unit test for the command

## Testing
- `composer install --no-interaction --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6873f114b52c832485451887c31409ae