### PR TITLE
Add subscription repository test

### DIFF
--- a/backend/tests/SubscriptionRepositoryTest.php
+++ b/backend/tests/SubscriptionRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Subscription;
+use App\Entity\User;
+use App\Enum\SubscriptionInterval;
+use App\Enum\UserRole;
+use App\Repository\SubscriptionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SubscriptionRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private SubscriptionRepository $subscriptionRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->subscriptionRepository = $container->get(SubscriptionRepository::class);
+
+        $tool = new SchemaTool($this->em);
+        $tool->dropSchema($this->em->getMetadataFactory()->getAllMetadata());
+        $tool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+    }
+
+    private function createUser(): User
+    {
+        $user = new User();
+        $user->setEmail('sub@example.com');
+        $user->setPassword('pw');
+        $user->setRoles([]);
+        $user->setRole(UserRole::CUSTOMER);
+        $user->setFirstName('A');
+        $user->setLastName('B');
+        $user->setActive(true);
+        $user->setCreatedAt(new \DateTimeImmutable());
+        $this->em->persist($user);
+        $this->em->flush();
+        return $user;
+    }
+
+    public function testFindDueSubscriptions(): void
+    {
+        $user = $this->createUser();
+        $now = new \DateTimeImmutable('2024-02-01');
+
+        $due = new Subscription();
+        $due->setUser($user)
+            ->setTitle('Due')
+            ->setAmount('10.00')
+            ->setStartsAt(new \DateTimeImmutable('2024-01-01'))
+            ->setNextDue(new \DateTimeImmutable('2024-01-01'))
+            ->setInterval(SubscriptionInterval::MONTHLY)
+            ->setActive(true)
+            ->setAutoRenew(true);
+        $this->em->persist($due);
+
+        $future = new Subscription();
+        $future->setUser($user)
+            ->setTitle('Future')
+            ->setAmount('10.00')
+            ->setStartsAt(new \DateTimeImmutable('2024-01-01'))
+            ->setNextDue(new \DateTimeImmutable('2024-03-01'))
+            ->setInterval(SubscriptionInterval::MONTHLY)
+            ->setActive(true)
+            ->setAutoRenew(true);
+        $this->em->persist($future);
+
+        $inactive = new Subscription();
+        $inactive->setUser($user)
+            ->setTitle('Inactive')
+            ->setAmount('10.00')
+            ->setStartsAt(new \DateTimeImmutable('2024-01-01'))
+            ->setNextDue(new \DateTimeImmutable('2024-01-01'))
+            ->setInterval(SubscriptionInterval::MONTHLY)
+            ->setActive(false)
+            ->setAutoRenew(true);
+        $this->em->persist($inactive);
+
+        $this->em->flush();
+
+        $result = $this->subscriptionRepository->findDueSubscriptions($now);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Due', $result[0]->getTitle());
+    }
+}

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -4,6 +4,11 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
+// Ensure Doctrine loads entity metadata during tests
+require_once dirname(__DIR__).'/src/Entity/Invoice.php';
+require_once dirname(__DIR__).'/src/Entity/InvoiceItem.php';
+require_once dirname(__DIR__).'/src/Entity/Subscription.php';
+
 if (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }


### PR DESCRIPTION
## Summary
- load invoice and subscription entities in test bootstrap
- add `SubscriptionRepositoryTest` verifying `findDueSubscriptions`

## Testing
- `./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6873f526aca883249dac94b712e8ddf0