### PR TITLE
Implement subscription management module

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,9 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from './modules/auth/Login'
 import Dashboard from './modules/dashboard/Dashboard'
 import { useAuth } from './modules/auth/AuthContext'
+import AuthGuard from './modules/auth/AuthGuard'
+import SubscriptionList from './modules/subscriptions/SubscriptionList'
+import SubscriptionForm from './modules/subscriptions/SubscriptionForm'
 
 function App() {
   const { token } = useAuth()
@@ -12,6 +15,22 @@ function App() {
       <Route
         path="/dashboard"
         element={token ? <Dashboard /> : <Navigate to="/login" replace />}
+      />
+      <Route
+        path="/admin/subscriptions"
+        element={
+          <AuthGuard role="admin">
+            <SubscriptionList />
+          </AuthGuard>
+        }
+      />
+      <Route
+        path="/admin/subscriptions/new"
+        element={
+          <AuthGuard role="admin">
+            <SubscriptionForm />
+          </AuthGuard>
+        }
       />
       <Route path="*" element={<Navigate to="/dashboard" replace />} />
     </Routes>

--- a/frontend/src/modules/auth/AuthGuard.tsx
+++ b/frontend/src/modules/auth/AuthGuard.tsx
@@ -1,0 +1,11 @@
+import { ReactElement } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from './AuthContext'
+
+export default function AuthGuard({ children, role }: { children: ReactElement; role?: 'admin' | 'staff' | 'customer' }) {
+  const { token, role: currentRole } = useAuth()
+  if (!token || (role && currentRole !== role)) {
+    return <Navigate to="/login" replace />
+  }
+  return children
+}

--- a/frontend/src/modules/subscriptions/SubscriptionForm.tsx
+++ b/frontend/src/modules/subscriptions/SubscriptionForm.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../../axios'
+import { SubscriptionData } from './types'
+
+const users = [
+  { id: 1, label: 'User 1' },
+  { id: 2, label: 'User 2' },
+]
+
+const horses = [
+  { id: 1, label: 'Horse 1' },
+  { id: 2, label: 'Horse 2' },
+]
+
+const stalls = [
+  { id: 1, label: 'Stall A' },
+  { id: 2, label: 'Stall B' },
+]
+
+function SubscriptionForm() {
+  const navigate = useNavigate()
+  const today = new Date().toISOString().split('T')[0]
+  const [type, setType] = useState<'USER' | 'HORSE' | 'STALL'>('USER')
+  const [assignment, setAssignment] = useState('')
+  const [title, setTitle] = useState('')
+  const [amount, setAmount] = useState('')
+  const [start, setStart] = useState(today)
+  const [autoRenew, setAutoRenew] = useState(true)
+  const [end, setEnd] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const payload: SubscriptionData & {
+      userId?: number
+      horseId?: number
+      stallUnitId?: number
+    } = {
+      type,
+      title: title || `Abo ${type}`,
+      amount: parseFloat(amount),
+      startsAt: start,
+      autoRenew,
+    }
+    if (end) payload.endDate = end
+    if (type === 'USER') payload.userId = parseInt(assignment, 10)
+    if (type === 'HORSE') payload.horseId = parseInt(assignment, 10)
+    if (type === 'STALL') payload.stallUnitId = parseInt(assignment, 10)
+
+    try {
+      await api.post('/subscriptions', payload)
+      navigate('/admin/subscriptions')
+    } catch (err) {
+      setError('Failed to save subscription')
+    }
+  }
+
+  let assignmentOptions
+  if (type === 'USER') {
+    assignmentOptions = users
+  } else if (type === 'HORSE') {
+    assignmentOptions = horses
+  } else {
+    assignmentOptions = stalls
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-4 bg-white">
+      <h1 className="text-2xl">Neues Abo</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <div>
+        <label className="block mb-1">Typ</label>
+        <select value={type} onChange={e => setType(e.target.value as any)} className="border p-2 w-full">
+          <option value="USER">USER</option>
+          <option value="HORSE">HORSE</option>
+          <option value="STALL">STALL</option>
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Zuweisung</label>
+        <select value={assignment} onChange={e => setAssignment(e.target.value)} className="border p-2 w-full">
+          <option value="">Bitte wählen</option>
+          {assignmentOptions.map(opt => (
+            <option key={opt.id} value={opt.id}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Titel</label>
+        <input value={title} onChange={e => setTitle(e.target.value)} className="border p-2 w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">Betrag</label>
+        <input type="number" step="0.01" value={amount} onChange={e => setAmount(e.target.value)} className="border p-2 w-full" />
+      </div>
+      <div>
+        <label className="block mb-1">Startdatum</label>
+        <input type="date" value={start} onChange={e => setStart(e.target.value)} className="border p-2 w-full" />
+      </div>
+      <div>
+        <label className="inline-flex items-center">
+          <input type="checkbox" checked={autoRenew} onChange={e => setAutoRenew(e.target.checked)} className="mr-2" />
+          AutoRenew
+        </label>
+      </div>
+      <div>
+        <label className="block mb-1">Enddatum</label>
+        <input type="date" value={end} onChange={e => setEnd(e.target.value)} className="border p-2 w-full" />
+      </div>
+      <button className="bg-blue-500 text-white px-4 py-2">Abo speichern</button>
+    </form>
+  )
+}
+
+export default SubscriptionForm

--- a/frontend/src/modules/subscriptions/SubscriptionList.tsx
+++ b/frontend/src/modules/subscriptions/SubscriptionList.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import api from '../../axios'
+import useMockData from './useMockData'
+import { SubscriptionData } from './types'
+
+function SubscriptionList() {
+  const mockData = useMockData()
+  const [subs, setSubs] = useState<SubscriptionData[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true)
+      try {
+        const res = await api.get('/subscriptions')
+        setSubs(res.data as SubscriptionData[])
+      } catch (err) {
+        setSubs(mockData)
+        setError('Failed to load data')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [mockData])
+
+  return (
+    <div className="p-4">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl">Aktive Abos</h1>
+        <Link
+          to="/admin/subscriptions/new"
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          + Neues Abo
+        </Link>
+      </div>
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr>
+            <th className="py-2 px-4 text-left">Typ</th>
+            <th className="py-2 px-4 text-left">Titel</th>
+            <th className="py-2 px-4 text-left">Betrag</th>
+            <th className="py-2 px-4 text-left">Start</th>
+            <th className="py-2 px-4 text-left">AutoRenew</th>
+            <th className="py-2 px-4 text-left">Ende</th>
+          </tr>
+        </thead>
+        <tbody>
+          {subs.map(s => (
+            <tr key={s.id} className="border-t">
+              <td className="py-2 px-4">{s.type}</td>
+              <td className="py-2 px-4">{s.title}</td>
+              <td className="py-2 px-4">{s.amount.toFixed ? s.amount.toFixed(2) : s.amount}</td>
+              <td className="py-2 px-4">{new Date(s.startsAt).toLocaleDateString()}</td>
+              <td className="py-2 px-4">{s.autoRenew ? 'Ja' : 'Nein'}</td>
+              <td className="py-2 px-4">
+                {s.endDate ? new Date(s.endDate).toLocaleDateString() : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default SubscriptionList

--- a/frontend/src/modules/subscriptions/types.ts
+++ b/frontend/src/modules/subscriptions/types.ts
@@ -1,0 +1,9 @@
+export type SubscriptionData = {
+  id?: number
+  type: 'USER' | 'HORSE' | 'STALL'
+  title: string
+  amount: number
+  startsAt: string
+  autoRenew: boolean
+  endDate?: string | null
+}

--- a/frontend/src/modules/subscriptions/useMockData.ts
+++ b/frontend/src/modules/subscriptions/useMockData.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import { SubscriptionData } from './types'
+
+export default function useMockData(): SubscriptionData[] {
+  return useMemo(
+    () => [
+      {
+        id: 1,
+        type: 'STALL',
+        title: 'Box 1',
+        amount: 300,
+        startsAt: '2024-01-01',
+        autoRenew: true,
+      },
+      {
+        id: 2,
+        type: 'HORSE',
+        title: 'Hufpflege',
+        amount: 50,
+        startsAt: '2024-02-01',
+        autoRenew: false,
+        endDate: '2024-08-01',
+      },
+    ],
+    []
+  )
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `AuthGuard` for role based routes
- implement admin subscription components with mock data
- add admin subscription routes
- add missing `tsconfig.json` for shared package

## Testing
- `npm run build`
- `./bin/phpunit` *(fails: unable to find phpunit script due to missing ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_e_68740761356c8324af963ebdf9ec7267