### PR TITLE
Add filtering for subscriptions and update tests

### DIFF
--- a/backend/src/Repository/SubscriptionRepository.php
+++ b/backend/src/Repository/SubscriptionRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Subscription;
+use App\Enum\SubscriptionType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -27,5 +28,24 @@ class SubscriptionRepository extends ServiceEntityRepository
             ->setParameter('now', $now)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @return Subscription[]
+     */
+    public function findFiltered(?SubscriptionType $type, bool $activeOnly): array
+    {
+        $qb = $this->createQueryBuilder('s');
+
+        if ($type) {
+            $qb->andWhere('s.subscriptionType = :type')
+                ->setParameter('type', $type);
+        }
+
+        if ($activeOnly) {
+            $qb->andWhere('s.active = true');
+        }
+
+        return $qb->getQuery()->getResult();
     }
 }


### PR DESCRIPTION
## Summary
- filter subscription list by type or active flag
- include related user, horse or stall info in subscription list
- add repository helper for filtered queries
- extend test coverage for subscription listing

## Testing
- `composer install --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit --configuration phpunit.dist.xml`

------
https://chatgpt.com/codex/tasks/task_e_687410ad9fec8324860a52cea0c5c8b5