### PR TITLE
Add HorseScale booking controllers

### DIFF
--- a/backend/src/Controller/HorseScale/AdminBookingController.php
+++ b/backend/src/Controller/HorseScale/AdminBookingController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller\HorseScale;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class AdminBookingController extends AbstractController
+{
+    #[Route('/horsescale/admin/bookings', name: 'horsescale_admin_bookings', methods: ['GET'])]
+    public function __invoke(): Response
+    {
+        // In a real application bookings would be fetched from the database
+        return $this->render('horsescale/admin_bookings.html.twig');
+    }
+}

--- a/backend/src/Controller/HorseScale/BookingFormController.php
+++ b/backend/src/Controller/HorseScale/BookingFormController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller\HorseScale;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class BookingFormController extends AbstractController
+{
+    #[Route('/horsescale/book', name: 'horsescale_booking_form', methods: ['GET', 'POST'])]
+    public function __invoke(Request $request): Response
+    {
+        if ($request->isMethod('POST')) {
+            // Here one would normally persist the booking request
+            $this->addFlash('success', 'Booking request received.');
+
+            return $this->redirectToRoute('horsescale_booking_form');
+        }
+
+        return $this->render('horsescale/booking_form.html.twig');
+    }
+}

--- a/backend/src/Controller/HorseScale/VerificationController.php
+++ b/backend/src/Controller/HorseScale/VerificationController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Controller\HorseScale;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class VerificationController extends AbstractController
+{
+    #[Route('/horsescale/verify/{code}', name: 'horsescale_verify', methods: ['GET'])]
+    public function __invoke(string $code): Response
+    {
+        // Normally the code would be looked up and validated
+        return $this->render('horsescale/verification.html.twig', [
+            'code' => $code,
+        ]);
+    }
+}

--- a/backend/templates/horsescale/admin_bookings.html.twig
+++ b/backend/templates/horsescale/admin_bookings.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}HorseScale Admin Bookings{% endblock %}
+
+{% block body %}
+<h1>Manage Bookings</h1>
+<p>This is a placeholder for the admin booking management interface.</p>
+{% endblock %}

--- a/backend/templates/horsescale/booking_form.html.twig
+++ b/backend/templates/horsescale/booking_form.html.twig
@@ -1,0 +1,18 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}HorseScale Booking{% endblock %}
+
+{% block body %}
+<h1>Book HorseScale Slot</h1>
+<form method="post">
+    <div>
+        <label>Name:</label>
+        <input type="text" name="name" required>
+    </div>
+    <div>
+        <label>Date:</label>
+        <input type="date" name="date" required>
+    </div>
+    <button type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/backend/templates/horsescale/verification.html.twig
+++ b/backend/templates/horsescale/verification.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}HorseScale Verification{% endblock %}
+
+{% block body %}
+<h1>QR Code Verification</h1>
+<p>Scanned code: {{ code }}</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add horse scale booking form, admin and verification controllers
- add twig templates for booking form, admin bookings list and verification

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium`
- `php bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6887a3ebe3d0832484c584f761485c56