### PR TITLE
Configure default locale and timezone

### DIFF
--- a/backend/config/packages/framework.yaml
+++ b/backend/config/packages/framework.yaml
@@ -1,6 +1,8 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
+    default_locale: 'de'
+    timezone: 'Europe/Berlin'
 
     # Note that the session will be started ONLY if you read or write from it.
     session: true

--- a/backend/config/packages/translation.yaml
+++ b/backend/config/packages/translation.yaml
@@ -1,5 +1,5 @@
 framework:
-    default_locale: en
+    default_locale: de
     translator:
         default_path: '%kernel.project_dir%/translations'
         providers:


### PR DESCRIPTION
## Summary
- set `default_locale` to `de`
- set timezone to Europe/Berlin in framework config
- switch translation config to German locale

## Testing
- `composer install --no-interaction` *(fails: required PHP extensions and version)*

------
https://chatgpt.com/codex/tasks/task_e_6887afb8a0488324bcbec425d1e156ce