### PR TITLE
Add HorseScale email templates and mailer

### DIFF
--- a/backend/src/Service/HorseScaleMailer.php
+++ b/backend/src/Service/HorseScaleMailer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\ScaleBooking;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+
+class HorseScaleMailer
+{
+    public function __construct(private readonly MailerInterface $mailer)
+    {
+    }
+
+    public function sendPendingBookingNotificationToAdmin(ScaleBooking $booking, string $adminEmail): void
+    {
+        $email = (new TemplatedEmail())
+            ->to(new Address($adminEmail))
+            ->subject('New HorseScale booking pending')
+            ->htmlTemplate('horsescale/emails/pending_notification.html.twig')
+            ->context(['booking' => $booking]);
+
+        $this->mailer->send($email);
+    }
+
+    public function sendPaymentRequest(ScaleBooking $booking, string $paymentUrl): void
+    {
+        $email = (new TemplatedEmail())
+            ->to(new Address($booking->getCustomerEmail(), $booking->getCustomerName()))
+            ->subject('HorseScale payment required')
+            ->htmlTemplate('horsescale/emails/payment_request.html.twig')
+            ->context([
+                'booking' => $booking,
+                'paymentUrl' => $paymentUrl,
+            ]);
+
+        $this->mailer->send($email);
+    }
+
+    public function sendPaymentConfirmation(ScaleBooking $booking, string $pdfPath, string $qrPath): void
+    {
+        $email = (new TemplatedEmail())
+            ->to(new Address($booking->getCustomerEmail(), $booking->getCustomerName()))
+            ->subject('HorseScale booking confirmed')
+            ->htmlTemplate('horsescale/emails/payment_confirmation.html.twig')
+            ->context(['booking' => $booking])
+            ->attachFromPath($pdfPath, 'booking.pdf')
+            ->attachFromPath($qrPath, 'qrcode.png');
+
+        $this->mailer->send($email);
+    }
+
+    public function sendResultEmail(ScaleBooking $booking): void
+    {
+        $email = (new TemplatedEmail())
+            ->to(new Address($booking->getCustomerEmail(), $booking->getCustomerName()))
+            ->subject('HorseScale result')
+            ->htmlTemplate('horsescale/emails/result_notification.html.twig')
+            ->context(['booking' => $booking]);
+
+        $this->mailer->send($email);
+    }
+}

--- a/backend/templates/horsescale/emails/payment_confirmation.html.twig
+++ b/backend/templates/horsescale/emails/payment_confirmation.html.twig
@@ -1,0 +1,3 @@
+<p>Hello {{ booking.customerName }},</p>
+<p>Thank you for your payment for {{ booking.horseName }} on {{ booking.bookingDateTime|date('Y-m-d H:i') }}.</p>
+<p>Your PDF confirmation and QR code are attached.</p>

--- a/backend/templates/horsescale/emails/payment_request.html.twig
+++ b/backend/templates/horsescale/emails/payment_request.html.twig
@@ -1,0 +1,3 @@
+<p>Hello {{ booking.customerName }},</p>
+<p>Your booking for {{ booking.horseName }} on {{ booking.bookingDateTime|date('Y-m-d H:i') }} is awaiting payment.</p>
+<p>Please complete payment here: <a href="{{ paymentUrl }}">{{ paymentUrl }}</a></p>

--- a/backend/templates/horsescale/emails/pending_notification.html.twig
+++ b/backend/templates/horsescale/emails/pending_notification.html.twig
@@ -1,0 +1,2 @@
+<h2>New HorseScale booking pending</h2>
+<p>{{ booking.customerName }} requested a HorseScale session for {{ booking.horseName }} on {{ booking.bookingDateTime|date('Y-m-d H:i') }}.</p>

--- a/backend/templates/horsescale/emails/result_notification.html.twig
+++ b/backend/templates/horsescale/emails/result_notification.html.twig
@@ -1,0 +1,3 @@
+<p>Hello {{ booking.customerName }},</p>
+<p>The weighing of {{ booking.horseName }} on {{ booking.bookingDateTime|date('Y-m-d H:i') }} is complete.</p>
+<p>The horse's weight is {{ booking.actualWeight }} kg.</p>


### PR DESCRIPTION
## Summary
- add mailer service to send HorseScale emails via Symfony Mailer
- create email templates for booking notifications, payment, confirmation and results

## Testing
- `php -l backend/src/Service/HorseScaleMailer.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6887ba23b6b8832490afd42daa98612b