### PR TITLE
Add QA docs and progress tracking

### DIFF
--- a/Projektplan_2025.md
+++ b/Projektplan_2025.md
@@ -1,0 +1,3 @@
+# Projektplan 2025
+
+Dieser Plan skizziert die anstehenden Meilensteine und Aufgaben für das Jahr 2025.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Inklusive Kundenportal, Buchungssystem, Zusatzleistungen, Rechnungsmodul und Auf
 Die Software steht unter der [MIT-Lizenz](LICENSE).
 
 > Generiert und verwaltet mit OpenAI Codex.
+
+## QA-Dokumente
+- `Projektplan_2025.md`: Überblick zu geplanten Meilensteinen
+- `deep_qa_audit.md`: laufende QA-Audits
+- `final_qa_report.md`: abschließender QA-Bericht

--- a/deep_qa_audit.md
+++ b/deep_qa_audit.md
@@ -1,0 +1,3 @@
+# Deep QA Audit
+
+Dokumentiert fortlaufende Prüfungen und Analysen im Rahmen der QA.

--- a/final_qa_report.md
+++ b/final_qa_report.md
@@ -1,0 +1,3 @@
+# Final QA Report
+
+Dieser Bericht fasst die Ergebnisse der Qualitätssicherung zusammen.

--- a/qa_status.json
+++ b/qa_status.json
@@ -1,0 +1,12 @@
+{
+  "domainModelingComplete": false,
+  "securityReviewDone": false,
+  "codeReviewed": false,
+  "documentationUpdated": false,
+  "pipelineGreen": false,
+  "deployChecklistCompleted": false,
+  "badgeRules": false,
+  "crossoverHandling": false,
+  "testsExist": false,
+  "certificateIssuanceLogic": false
+}

--- a/src/Equed/CertBundle/qa_checklist.yaml
+++ b/src/Equed/CertBundle/qa_checklist.yaml
@@ -1,13 +1,13 @@
 profile: equed
 DoD:
   - requirement: domainModelingComplete
-    status: pending
+    status: in-progress
   - requirement: securityReviewDone
     status: pending
   - requirement: codeReviewed
     status: pending
   - requirement: documentationUpdated
-    status: pending
+    status: in-progress
   - requirement: pipelineGreen
     status: pending
   - requirement: deployChecklistCompleted


### PR DESCRIPTION
## Summary
- add placeholder QA documents for project planning and audits
- update README with QA document references
- include initial `qa_status.json`
- mark some requirements as `in-progress` in `qa_checklist.yaml`

## Testing
- `composer install --ignore-platform-reqs` *(fails: lock file mismatch)*
- `./vendor/bin/phpunit -c phpunit.dist.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ba3227f08324a74f3980569d8379