### PR TITLE
Add HorseScale admin templates

### DIFF
--- a/backend/templates/horsescale/admin/bookings_list.html.twig
+++ b/backend/templates/horsescale/admin/bookings_list.html.twig
@@ -1,0 +1,46 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}HorseScale Bookings{% endblock %}
+
+{% block stylesheets %}
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+{% endblock %}
+
+{% block javascripts %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block body %}
+<div class="container mt-4">
+    <h1 class="mb-3">Bookings</h1>
+    <table class="table table-striped table-responsive">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Customer</th>
+                <th>Horse</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for booking in bookings %}
+            <tr>
+                <td>{{ booking.bookingDateTime|date('Y-m-d H:i') }}</td>
+                <td>{{ booking.customerName }}</td>
+                <td>{{ booking.horseName }}</td>
+                <td>{{ booking.status }}</td>
+                <td>
+                    <a class="btn btn-sm btn-primary" href="{{ path('horsescale_admin_booking_edit', {id: booking.id}) }}">Edit</a>
+                    <a class="btn btn-sm btn-secondary" href="{{ path('horsescale_admin_booking_email', {id: booking.id}) }}">Send Email</a>
+                </td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="5">No bookings found.</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/backend/templates/horsescale/admin/email_booking.html.twig
+++ b/backend/templates/horsescale/admin/email_booking.html.twig
@@ -1,0 +1,21 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Send Booking Email{% endblock %}
+
+{% block stylesheets %}
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+{% endblock %}
+
+{% block javascripts %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block body %}
+<div class="container mt-4">
+    <h1 class="mb-3">Send Email</h1>
+    <p>Send result email to {{ booking.customerEmail }}.</p>
+    <form method="post">
+        <button type="submit" class="btn btn-success">Send Email</button>
+    </form>
+</div>
+{% endblock %}

--- a/backend/templates/horsescale/admin/update_booking.html.twig
+++ b/backend/templates/horsescale/admin/update_booking.html.twig
@@ -1,0 +1,32 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Edit Booking{% endblock %}
+
+{% block stylesheets %}
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+{% endblock %}
+
+{% block javascripts %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block body %}
+<div class="container mt-4">
+    <h1 class="mb-3">Edit Booking</h1>
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select">
+                {% for status in statuses %}
+                    <option value="{{ status }}" {{ booking.status == status ? 'selected' : '' }}>{{ status|title }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Actual Weight (kg)</label>
+            <input type="number" step="0.01" name="actualWeight" value="{{ booking.actualWeight }}" class="form-control">
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin listing, edit, and email Twig templates for HorseScale bookings

## Testing
- `composer install --no-interaction --ignore-platform-reqs` *(fails: lock file issues)*

------
https://chatgpt.com/codex/tasks/task_e_6887cd58ce7083249fb4c4292e77e0a0