### PR TITLE
Add JWT auth controller and configure security

### DIFF
--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -16,12 +16,6 @@ security:
             pattern: ^/api
             stateless: true
             provider: app_user_provider
-            json_login:
-                check_path: /api/login
-                username_path: email
-                password_path: password
-                success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
             jwt: ~
 
             # activate different ways to authenticate
@@ -34,6 +28,7 @@ security:
     # Note: Only the *first* access control that matches will be used
     access_control:
         - { path: ^/api/login, roles: PUBLIC_ACCESS }
+        - { path: ^/api/register, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
 
 when@test:

--- a/backend/src/Controller/AuthController.php
+++ b/backend/src/Controller/AuthController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+class AuthController extends AbstractController
+{
+    #[Route('/api/register', name: 'api_register', methods: ['POST'])]
+    public function register(
+        Request $request,
+        EntityManagerInterface $em,
+        UserPasswordHasherInterface $passwordHasher,
+        JWTTokenManagerInterface $jwtManager
+    ): JsonResponse {
+        $data = json_decode($request->getContent(), true);
+        $email = $data['email'] ?? null;
+        $password = $data['password'] ?? null;
+
+        if (!$email || !$password) {
+            return $this->json(['message' => 'Email and password are required'], 400);
+        }
+
+        if ($em->getRepository(User::class)->findOneBy(['email' => $email])) {
+            return $this->json(['message' => 'Email already exists'], 400);
+        }
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setPassword($passwordHasher->hashPassword($user, $password));
+
+        $em->persist($user);
+        $em->flush();
+
+        $token = $jwtManager->create($user);
+
+        return $this->json(['token' => $token], 201);
+    }
+
+    #[Route('/api/login', name: 'api_login', methods: ['POST'])]
+    public function login(
+        Request $request,
+        EntityManagerInterface $em,
+        UserPasswordHasherInterface $passwordHasher,
+        JWTTokenManagerInterface $jwtManager
+    ): JsonResponse {
+        $data = json_decode($request->getContent(), true);
+        $email = $data['email'] ?? null;
+        $password = $data['password'] ?? null;
+
+        if (!$email || !$password) {
+            return $this->json(['message' => 'Email and password are required'], 400);
+        }
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => $email]);
+        if (!$user || !$passwordHasher->isPasswordValid($user, $password)) {
+            return $this->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $token = $jwtManager->create($user);
+
+        return $this->json(['token' => $token]);
+    }
+}

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -3,11 +3,12 @@
 namespace App\Entity;
 
 use App\Enum\UserRole;
+use App\Repository\UserRepository;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Doctrine\ORM\Mapping as ORM;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: UserRepository::class)]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]

--- a/backend/src/Repository/UserRepository.php
+++ b/backend/src/Repository/UserRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+}


### PR DESCRIPTION
## Summary
- implement register and login endpoints issuing JWT tokens
- add UserRepository and update User entity
- configure security for stateless JWT authentication

## Testing
- `./bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install` *(fails: Required package "dompdf/dompdf" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f3ef521483248ecbb86e2dacc651