### PR TITLE
Use unzip for build artifacts

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -61,7 +61,7 @@ run gh run download "$BUILD_ID" --dir "$ARTIFACT_DIR"
 
 ARCHIVE=$(find "$ARTIFACT_DIR" -maxdepth 1 -type f | head -n1 || true)
 if [[ -n "$ARCHIVE" ]]; then
-    run tar -xf "$ARCHIVE" -C "$TARGET_DIR"
+    run unzip "$ARCHIVE" -d "$TARGET_DIR"
 else
     log "No artifact archive found in $ARTIFACT_DIR" >&2
 fi


### PR DESCRIPTION
## Summary
- Use `unzip` to extract build artifacts in deploy script

## Testing
- `npm test`
- `npm run lint`
- `./vendor/bin/phpunit`
- `shellcheck scripts/deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c53a34a4608324b6ed16f5453a6956