### PR TITLE
test: add agreements module tests

### DIFF
--- a/frontend/src/modules/agreements/__tests__/AdminAgreementUpload.test.tsx
+++ b/frontend/src/modules/agreements/__tests__/AdminAgreementUpload.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { createElement } from 'react'
-import AdminAgreementUpload from './AdminAgreementUpload'
-import * as agreementsApi from '../../api/agreements'
+import AdminAgreementUpload from '../AdminAgreementUpload'
+import * as agreementsApi from '../../../api/agreements'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (s: string) => s }),
 }))
 
-vi.mock('../../api/agreements', async actual => {
+vi.mock('../../../api/agreements', async actual => {
   const mod = await actual()
   return {
     ...mod,
@@ -43,6 +43,15 @@ describe('AdminAgreementUpload', () => {
         version: '1.0',
         file,
       })
+    })
+  })
+
+  it('does not submit without file', async () => {
+    render(createElement(AdminAgreementUpload))
+    fireEvent.click(screen.getByText('agreements.upload'))
+
+    await waitFor(() => {
+      expect(agreementsApi.uploadAgreement).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/modules/agreements/__tests__/AgreementList.test.tsx
+++ b/frontend/src/modules/agreements/__tests__/AgreementList.test.tsx
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { createElement } from 'react'
-import AgreementList from './AgreementList'
-import { loadAll } from './agreementsSlice'
-import * as agreementsApi from '../../api/agreements'
+import AgreementList from '../AgreementList'
+import { loadAll } from '../agreementsSlice'
+import * as agreementsApi from '../../../api/agreements'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (s: string) => s }),
 }))
 
-vi.mock('./agreementsSlice', async actual => {
+vi.mock('../agreementsSlice', async actual => {
   const mod = await actual()
   return {
     ...mod,
@@ -18,7 +18,7 @@ vi.mock('./agreementsSlice', async actual => {
   }
 })
 
-vi.mock('../../api/agreements', async actual => {
+vi.mock('../../../api/agreements', async actual => {
   const mod = await actual()
   return {
     ...mod,

--- a/frontend/src/modules/agreements/__tests__/AgreementRoutes.test.tsx
+++ b/frontend/src/modules/agreements/__tests__/AgreementRoutes.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import AgreementList from '../AgreementList'
+import AdminAgreementUpload from '../AdminAgreementUpload'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}))
+
+describe('Agreement routes', () => {
+  const agreements: any[] = []
+  const store = {
+    getState: () => ({ agreements: { items: agreements } }),
+    dispatch: vi.fn(),
+    subscribe: vi.fn(),
+  }
+
+  it('renders AgreementList for /agreements', () => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/agreements']}>
+          <Routes>
+            <Route path="/agreements" element={<AgreementList />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    )
+    expect(screen.getByText('agreements.title')).toBeTruthy()
+  })
+
+  it('renders AdminAgreementUpload for /admin/agreements', () => {
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/admin/agreements']}>
+          <Routes>
+            <Route path="/admin/agreements" element={<AdminAgreementUpload />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    )
+    expect(screen.getByText('agreements.upload')).toBeTruthy()
+  })
+})

--- a/frontend/src/modules/agreements/__tests__/agreementsSlice.test.ts
+++ b/frontend/src/modules/agreements/__tests__/agreementsSlice.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import reducer, {
   loadAll,
   giveConsent,
-} from './agreementsSlice'
+} from '../agreementsSlice'
 
 describe('agreementsSlice', () => {
   it('handles loadAll.fulfilled', () => {


### PR DESCRIPTION
## Summary
- move agreement module tests into `__tests__` directory
- add validation coverage for `AdminAgreementUpload`
- cover routing paths for agreements pages

## Testing
- `npm test src/modules/agreements`


------
https://chatgpt.com/codex/tasks/task_e_68c53b35a168832481df7abc88dbf289