### PR TITLE
chore: ignore local phpstan config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@ dist/
 backend/config/jwt/private.pem
 !backend/.env
 
-.phpstan.neon
-
 var/*
 !var/phpstan/
 var/phpstan/*
 !var/phpstan/.gitkeep
+
+.phpstan.neon


### PR DESCRIPTION
## Summary
- append `.phpstan.neon` to the root `.gitignore` so personal PHPStan overrides remain untracked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c55fd322308324ba0bb900411c4aff