### PR TITLE
docs: add PHPStan static analysis instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ npm test
 npm run build
 ```
 
+## Static Analysis
+Static analysis is handled by [PHPStan](https://phpstan.org/):
+
+```bash
+vendor/bin/phpstan analyse --configuration=.phpstan.neon.dist
+```
+
+The default memory limit is `--memory-limit=512M`. Override it locally if needed:
+
+```bash
+vendor/bin/phpstan analyse --configuration=.phpstan.neon.dist --memory-limit=1G
+```
+
 ## Workaround note for `ext-sodium`
 Some environments lack the `ext-sodium` PHP extension. Use
 `composer install --ignore-platform-req=ext-sodium` to bypass the requirement during installation.


### PR DESCRIPTION
## Summary
- document PHPStan static analysis usage and memory limit options in README

## Testing
- `vendor/bin/phpunit`
- `backend/vendor/bin/phpstan analyse --configuration=.phpstan.neon.dist` *(fails: Unexpected item 'parameters › memoryLimit')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c562b9514883249610bdefcf454b16