### PR TITLE
Run PHPStan separately for entity, service, and controller

### DIFF
--- a/src/ci.yml
+++ b/src/ci.yml
@@ -59,10 +59,25 @@ jobs:
         working-directory: backend
         run: find src -name '*.php' -print0 | xargs -0 -n1 php -l
 
-      - name: Analyse backend with PHPStan
+      - name: Analyse backend Entity with PHPStan
+        working-directory: backend
         run: |
-          vendor/bin/phpstan analyse \
-            --configuration=.phpstan.neon.dist \
+          vendor/bin/phpstan analyse src/Entity \
+            --configuration=../.phpstan.neon.dist \
+            --memory-limit=512M
+
+      - name: Analyse backend Service with PHPStan
+        working-directory: backend
+        run: |
+          vendor/bin/phpstan analyse src/Service \
+            --configuration=../.phpstan.neon.dist \
+            --memory-limit=512M
+
+      - name: Analyse backend Controller with PHPStan
+        working-directory: backend
+        run: |
+          vendor/bin/phpstan analyse src/Controller \
+            --configuration=../.phpstan.neon.dist \
             --memory-limit=512M
 
       - name: Test backend with coverage


### PR DESCRIPTION
## Summary
- Split PHPStan analysis into dedicated steps for backend Entity, Service, and Controller directories
- Use shared root configuration and memory limit for each analysis

## Testing
- `/tmp/go/bin/actionlint .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c564b7ae708324aff3aec888d9df65