### PR TITLE
docs: add security updates section

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,3 +20,10 @@ npm run lint
 
 Dieser Befehl wird ebenfalls in der CI-Pipeline ausgeführt.
 
+## Security Updates
+
+- Run `npm audit` regularly to check for vulnerable dependencies.
+- Apply fixes with `npm audit fix`.
+- Integrate `npm audit` into the CI pipeline so issues are detected early.
+- After updating dependencies, rerun `npm run lint`, `npm test`, and `npm run build` to ensure the project remains stable.
+


### PR DESCRIPTION
## Summary
- document `npm audit` usage and integration in frontend
- remind developers to rerun lint, tests, and build after dependency updates

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c586ef70748324b691569a9e2d4428