### PR TITLE
docs: set release date for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [1.0.0] - 2024-XX-XX
+## [1.0.0] - 2025-09-14
 ### Added
 - Symfony 7.3 backend with Auth, Booking, Stripe, QR codes, Docs, Mail
 - React/Redux Toolkit frontend with Vite, Vitest, ESLint, i18n


### PR DESCRIPTION
## Summary
- replace placeholder date in changelog with actual release date

## Testing
- `npm test`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68c67c402e88832498b8184a4faed00e