### PR TITLE
Narrow PHPStan analysis to production code

### DIFF
--- a/.phpstan.neon.dist
+++ b/.phpstan.neon.dist
@@ -2,4 +2,8 @@ parameters:
   level: 6
   paths:
     - backend/src
+  excludePaths:
+    - */tests/*
+    - backend/config
+    - backend/public
   tmpDir: var/phpstan


### PR DESCRIPTION
## Summary
- configure PHPStan to analyze only backend source code and exclude tests and framework boilerplate

## Testing
- `backend/vendor/bin/phpstan analyse -c .phpstan.neon.dist --memory-limit=512M` *(fails: 63 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c68c8389c08324bddd1fd23d6cf611