### PR TITLE
Run migrations from target directory during deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -81,6 +81,9 @@ else
     log "No artifact archive found in $ARTIFACT_DIR" >&2
 fi
 
+log "Changing to target directory $TARGET_DIR"
+cd "$TARGET_DIR"
 run php bin/console doctrine:migrations:migrate --no-interaction
+cd - >/dev/null
 
 run sudo systemctl start app


### PR DESCRIPTION
## Summary
- ensure `deploy.sh` runs migrations in the specified target directory and restores the original location

## Testing
- `scripts/deploy.sh --dry-run 456 /tmp/target-dir`


------
https://chatgpt.com/codex/tasks/task_e_68c68f47425c832494925605ab36bb61