### PR TITLE
fix: align MeController security type for PHPStan

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The default memory limit is `--memory-limit=512M`. Override it locally if needed
 vendor/bin/phpstan analyse --configuration=.phpstan.neon.dist --memory-limit=1G
 ```
 
+- PHPStan-Level 8 prüft den MeController auf korrekte Typen; Fehler durch falsche Signatur wurden korrigiert.
+
 ## Doctrine Schema Fix
 The Horse ↔ StallUnit relationship now stores a nullable `stall_unit_id` foreign key on the `horse` table. Horses reference stall units through a **ManyToOne** association, and each stall unit provides the inverse side with **OneToMany** or **OneToOne** mapping depending on configuration. Removing a stall unit automatically sets `horse.stall_unit_id` to `NULL` instead of deleting the horse. After pulling these changes, regenerate and apply migrations:
 

--- a/backend/src/Controller/MeController.php
+++ b/backend/src/Controller/MeController.php
@@ -6,7 +6,7 @@ use App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MeController extends AbstractController


### PR DESCRIPTION
## Summary
- fix MeController to import correct Security service
- document PHPStan level 8 check in README

## Testing
- `vendor/bin/phpstan analyse --memory-limit=512M src`
- `./bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68c72728ccf08324b3f62e9694bbdaa7