### PR TITLE
Fix deprecations and enable subscription command tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ npm test
 npm run build
 ```
 
+## Testing
+The backend uses PHPUnit 12. To run the test suite without deprecations or skipped tests:
+
+```bash
+cd backend
+./bin/phpunit --testdox
+```
+
+Tests that depend on external services should be tagged with `@group external` and are excluded from the core suite by default.
+
 ## Static Analysis
 Static analysis is handled by [PHPStan](https://phpstan.org/):
 

--- a/backend/src/Command/ProcessSubscriptionsCommand.php
+++ b/backend/src/Command/ProcessSubscriptionsCommand.php
@@ -48,17 +48,18 @@ class ProcessSubscriptionsCommand extends Command
             $period = $subscription->getNextDue()->format('Y-m');
 
             $invoice = $this->invoiceRepository->findOneBy([
-                'user' => $user->getEmail(),
+                'user' => $user,
                 'period' => $period,
             ]);
 
             if (!$invoice) {
                 $invoice = new Invoice();
-                $invoice->setUser($user->getEmail());
+                $invoice->setUser($user);
                 $invoice->setNumber(uniqid('INV-'));
                 $invoice->setPeriod($period);
                 $invoice->setCreatedAt(new \DateTimeImmutable());
                 $invoice->setStatus(InvoiceStatus::SENT);
+                $invoice->setCurrency('USD');
                 $invoice->setTotal('0.00');
                 $this->em->persist($invoice);
             }

--- a/backend/src/Entity/Invoice.php
+++ b/backend/src/Entity/Invoice.php
@@ -29,6 +29,12 @@ class Invoice
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $stripePaymentId = null;
 
+    #[ORM\Column(type: 'string', length: 20, nullable: true)]
+    private ?string $number = null;
+
+    #[ORM\Column(type: 'string', length: 7, nullable: true)]
+    private ?string $period = null;
+
     #[ORM\Column(type: 'decimal', precision: 10, scale: 2)]
     private string $amount;
 
@@ -96,6 +102,28 @@ class Invoice
         return $this;
     }
 
+    public function getNumber(): ?string
+    {
+        return $this->number;
+    }
+
+    public function setNumber(?string $number): self
+    {
+        $this->number = $number;
+        return $this;
+    }
+
+    public function getPeriod(): ?string
+    {
+        return $this->period;
+    }
+
+    public function setPeriod(?string $period): self
+    {
+        $this->period = $period;
+        return $this;
+    }
+
     public function getAmount(): string
     {
         return $this->amount;
@@ -104,6 +132,17 @@ class Invoice
     public function setAmount(string $amount): self
     {
         $this->amount = $amount;
+        return $this;
+    }
+
+    public function getTotal(): string
+    {
+        return $this->amount;
+    }
+
+    public function setTotal(string $total): self
+    {
+        $this->amount = $total;
         return $this;
     }
 

--- a/backend/src/Repository/InvoiceRepository.php
+++ b/backend/src/Repository/InvoiceRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Invoice;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -19,11 +20,11 @@ class InvoiceRepository extends ServiceEntityRepository
     /**
      * @return Invoice[]
      */
-    public function findByUser(string $email): array
+    public function findByUser(User $user): array
     {
         return $this->createQueryBuilder('i')
-            ->where('i.user = :email')
-            ->setParameter('email', $email)
+            ->where('i.user = :user')
+            ->setParameter('user', $user)
             ->orderBy('i.createdAt', 'DESC')
             ->getQuery()
             ->getResult();

--- a/backend/tests/ProcessSubscriptionsCommandTest.php
+++ b/backend/tests/ProcessSubscriptionsCommandTest.php
@@ -72,9 +72,6 @@ class ProcessSubscriptionsCommandTest extends KernelTestCase
 
     public function testProcessSubscriptions(): void
     {
-        if (!property_exists(Invoice::class, 'period')) {
-            $this->markTestSkipped('Invoice entity lacks period field');
-        }
         $user = $this->createUser();
 
         $subscription = new Subscription();
@@ -99,7 +96,7 @@ class ProcessSubscriptionsCommandTest extends KernelTestCase
         $output = $tester->getDisplay();
         $this->assertStringContainsString('1 subscriptions processed', $output);
 
-        $invoices = $this->invoiceRepository->findByUser($user->getEmail());
+        $invoices = $this->invoiceRepository->findByUser($user);
         $this->assertCount(1, $invoices);
         $invoice = $invoices[0];
         $items = $this->em->getRepository(InvoiceItem::class)->findBy(['invoice' => $invoice]);
@@ -113,9 +110,6 @@ class ProcessSubscriptionsCommandTest extends KernelTestCase
 
     public function testProcessStallSubscriptions(): void
     {
-        if (!property_exists(Invoice::class, 'period')) {
-            $this->markTestSkipped('Invoice entity lacks period field');
-        }
         $user = $this->createUser();
         $stall = $this->createStallUnit();
 
@@ -139,7 +133,7 @@ class ProcessSubscriptionsCommandTest extends KernelTestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
 
-        $invoices = $this->invoiceRepository->findByUser($user->getEmail());
+        $invoices = $this->invoiceRepository->findByUser($user);
         $this->assertCount(1, $invoices);
         $invoice = $invoices[0];
         $items = $this->em->getRepository(InvoiceItem::class)->findBy(['invoice' => $invoice]);
@@ -154,9 +148,6 @@ class ProcessSubscriptionsCommandTest extends KernelTestCase
 
     public function testProcessSubscriptionsWithEndDate(): void
     {
-        if (!property_exists(Invoice::class, 'period')) {
-            $this->markTestSkipped('Invoice entity lacks period field');
-        }
         $user = $this->createUser();
 
         $subscription = new Subscription();

--- a/backend/tests/ScaleBookingServiceTest.php
+++ b/backend/tests/ScaleBookingServiceTest.php
@@ -41,7 +41,7 @@ class ScaleBookingServiceTest extends TestCase
         $slotService->expects($this->once())->method('isSlotAvailable')->with($slot)->willReturn(true);
 
         $qr = $this->createMock(QrCodeGenerator::class);
-        $qr->expects($this->once())->method('generate')->with($this->isType('string'));
+        $qr->expects($this->once())->method('generate')->with($this->isString());
 
         $service = new ScaleBookingService($slotService, $em, $qr);
 


### PR DESCRIPTION
## Summary
- replace deprecated `isType('string')` assertion with `isString()`
- expand Invoice entity with number and period fields and total helpers
- adjust subscription processing command and repository to use user relation
- unskip subscription command tests and document testing instructions

## Testing
- `cd backend && ./bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68c72b6384148324b7d57f36a3e75452