### PR TITLE
Ensure target dir exists before deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -63,6 +63,10 @@ if $DRY_RUN; then
     mkdir -p "$ARTIFACT_DIR"
 fi
 
+# Ensure the target directory exists before any find/cp/rsync operations
+log "Ensuring target directory exists at $TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
 run sudo systemctl stop app
 
 run rm -rf "$ARTIFACT_DIR"
@@ -81,8 +85,13 @@ else
     log "No artifact archive found in $ARTIFACT_DIR" >&2
 fi
 
-log "Changing to target directory $TARGET_DIR"
-cd "$TARGET_DIR"
+if [[ -d "$TARGET_DIR" ]]; then
+    log "Changing to target directory $TARGET_DIR"
+    cd "$TARGET_DIR"
+else
+    log "Target directory $TARGET_DIR does not exist" >&2
+    exit 1
+fi
 run php bin/console doctrine:migrations:migrate --no-interaction
 cd - >/dev/null
 


### PR DESCRIPTION
## Summary
- Always create the target deployment directory before any file operations, even during dry runs
- Confirm the target directory exists before changing into it to run migrations

## Testing
- `bash -n scripts/deploy.sh`
- `bash scripts/deploy.sh --dry-run 123 /tmp/test-target`
- `shellcheck scripts/deploy.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c730e9566c832483a046d4dc5419a9