### PR TITLE
Run find for artifact archive in dry-run mode

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,12 +75,8 @@ run rm -rf "$ARTIFACT_DIR"
 run mkdir -p "$ARTIFACT_DIR"
 run gh run download "$BUILD_ID" --dir "$ARTIFACT_DIR"
 
-if $DRY_RUN; then
-    ARCHIVE="$ARTIFACT_DIR/dummy.zip"
-    log "Simulating artifact archive at $ARCHIVE"
-else
-    ARCHIVE=$(find "$ARTIFACT_DIR" -maxdepth 1 -type f 2>/dev/null | head -n1 || true)
-fi
+# Always attempt to locate an artifact archive, even in dry-run mode
+ARCHIVE=$(find "$ARTIFACT_DIR" -maxdepth 1 -type f 2>/dev/null | head -n1 || true)
 if [[ -n "$ARCHIVE" ]]; then
     run unzip "$ARCHIVE" -d "$TARGET_DIR"
 else


### PR DESCRIPTION
## Summary
- Always locate the deployment artifact archive using `find ... 2>/dev/null`
- Remove dummy archive path and search even during dry-run

## Testing
- `bash -n scripts/deploy.sh`
- `shellcheck scripts/deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c7328d64b8832492c6444b7226f357