### PR TITLE
Document deploy script dry-run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ scripts/deploy.sh <build-id> <target-dir>
 Use a dry run to test the commands without making changes:
 
 ```bash
-bash scripts/deploy.sh --dry-run <build-id> <target-dir>
+bash scripts/deploy.sh --dry-run 123 /tmp/deploy
 ```
 
-In dry-run mode the script creates a dummy artifact directory and suppresses missing-directory errors, making it safe for testing. Full automation with Docker or Kubernetes may be added later.
+In dry-run mode the script logs each command instead of executing it. It also creates dummy artifact and target directories, making it safe for testing. Real deployments run the commands and apply the downloaded artifacts to the target directory. Full automation with Docker or Kubernetes may be added later.
 
 ## Rechnungen
 


### PR DESCRIPTION
## Summary
- document `bash scripts/deploy.sh --dry-run 123 /tmp/deploy` example
- explain that dry-run logs commands and creates dummy artifact/target directories

## Testing
- ⚠️ `npm test` (missing package.json)
- ⚠️ `cd backend && ./bin/phpunit --testdox` (missing simple-phpunit.php)
- ✅ `bash scripts/deploy.sh --dry-run 123 /tmp/deploy-example`

------
https://chatgpt.com/codex/tasks/task_e_68c733b4fe40832496c7d617c3e223ca