### PR TITLE
Add Dockerfiles for automated dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ To deploy with Docker Compose:
 
 ```bash
 cp .env.example .env
-docker compose up -d
+docker compose up -d --build
 ```
+
+- All Composer and NPM dependencies are installed automatically during the image build.
+- The frontend is served as an Nginx static server.
 
 The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:8.3-fpm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git unzip libpq-dev libicu-dev libzip-dev \
+    && docker-php-ext-install intl pdo_pgsql zip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+COPY . .
+
+RUN composer install --no-interaction --optimize-autoloader
+
+EXPOSE 8000
+CMD ["php", "-S", "0.0.0.0:8000", "-t", "public"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add backend Dockerfile that installs Composer deps and runs PHP server
- add frontend Dockerfile that builds the app and serves it with Nginx
- document one-command deployment with automatic Composer and NPM installs

## Testing
- `cd backend && ./bin/phpunit --testdox` *(fails: Unable to find the `simple-phpunit.php` script)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c96e05460c832494e4324fc2618c52