### PR TITLE
Configure nginx-proxy with automatic SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,26 @@ git push origin v1.0.0
 
 To deploy with Docker Compose:
 
-```bash
-cp .env.example .env
-docker compose up -d --build
-```
+1. Copy `.env.example` to `.env` and set the domain and email address used for certificates:
+
+   ```
+   DOMAIN=app.silent-oak-ranch.de
+   LETSENCRYPT_EMAIL=info@silent-oak-ranch.de
+   ```
+
+2. Start the stack:
+
+   ```bash
+   docker compose up -d --build
+   ```
 
 - All Composer and NPM dependencies are installed automatically during the image build.
 - The frontend is served as an Nginx static server.
 
-The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt.
+The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt. The proxy routes requests based on the path:
+
+- https://app.silent-oak-ranch.de → Frontend (Port 3000)
+- https://app.silent-oak-ranch.de/api → Backend (Port 8000)
 
 ## Deployment-Skript
 CI builds artifacts for each successful workflow run. After verifying the build in CI, deploy the artifact manually:

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -1,7 +1,6 @@
 server {
     listen 80 default_server;
     server_name _;
-    location / {
-        return 503;
-    }
+
+    return 444;
 }

--- a/proxy/vhost.d/app.silent-oak-ranch.de
+++ b/proxy/vhost.d/app.silent-oak-ranch.de
@@ -1,0 +1,9 @@
+location /api {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+location / {
+    proxy_pass http://frontend:3000;
+}


### PR DESCRIPTION
## Summary
- add nginx fallback `default.conf` rejecting unknown hosts
- document domain and certificate variables for proxy setup
- route `/api` to backend and root to frontend via `vhost.d`

## Testing
- `npm test` *(fails: vitest: not found)*
- `./bin/phpunit --testdox` *(fails: simple-phpunit.php not found)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c970be53248324b87433379c0a62f1