### PR TITLE
Update frontend Docker build to serve on port 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To deploy with Docker Compose:
 
 The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt. The proxy routes requests based on the path:
 
-- https://app.silent-oak-ranch.de → Frontend (Port 3000)
+- https://app.silent-oak-ranch.de → Frontend (Port 80)
 - https://app.silent-oak-ranch.de/api → Backend (Port 8000)
 
 ## Deployment-Skript

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
   frontend:
     build: ./frontend
     expose:
-      - "3000"
+      - "80"
     environment:
       VIRTUAL_HOST: "${DOMAIN}"
-      VIRTUAL_PORT: "3000"
+      VIRTUAL_PORT: "80"
       LETSENCRYPT_HOST: "${DOMAIN}"
       LETSENCRYPT_EMAIL: "${LETSENCRYPT_EMAIL}"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:20-alpine AS build
-
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install
+RUN npm install --frozen-lockfile
 
 COPY . .
 RUN npm run build
 
 FROM nginx:alpine
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
 
-EXPOSE 3000
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/proxy/vhost.d/app.silent-oak-ranch.de
+++ b/proxy/vhost.d/app.silent-oak-ranch.de
@@ -5,5 +5,5 @@ location /api {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 location / {
-    proxy_pass http://frontend:3000;
+    proxy_pass http://frontend:80;
 }


### PR DESCRIPTION
## Summary
- replace the frontend Dockerfile with a builder/nginx multi-stage image and ship a custom nginx configuration
- update docker-compose and proxy settings to expose the frontend on port 80
- refresh the README to document the new frontend port

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97a1c26c08324bd1d151baaf8f583