### PR TITLE
Add dockerignore for frontend build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.gitignore
+*.log
+Dockerfile
+nginx.conf
+.vscode
+.DS_Store


### PR DESCRIPTION
## Summary
- add a .dockerignore file to the frontend project to keep common development artefacts out of the Docker build context

## Testing
- not run (docker CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68c97f157c448324b6b6e9764fc3e25f