### PR TITLE
Add backend dockerignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+.git
+vendor
+node_modules
+tests/_output
+*.log
+Dockerfile


### PR DESCRIPTION
## Summary
- add a .dockerignore file for the backend service to reduce build context size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9825ff5788324ab8488180b049877