### PR TITLE
Update deploy workflow to use SSH-based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,67 +2,45 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
-  build:
+  deploy:
+    name: Deploy application
     runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_HOST: ${{ secrets.SSH_HOST }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
         with:
-          php-version: 8.2
+          ssh-private-key: ${{ secrets.SSH_KEY }}
 
-      - name: Install backend dependencies
-        working-directory: backend
-        run: composer install --no-interaction --prefer-dist --ignore-platform-req=ext-sodium
-
-      - name: Test backend
-        working-directory: backend
-        run: ./bin/phpunit
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Lint frontend
-        working-directory: frontend
-        run: npm run lint
-
-      - name: Test frontend
-        working-directory: frontend
-        run: npm test -- --run
-
-      - name: Build frontend
-        working-directory: frontend
-        run: npm run build
-
-      - name: Package backend build
-        working-directory: backend
+      - name: Ensure target directory exists
         run: |
-          mkdir -p var/cache
-          zip -r backend-build.zip vendor var/cache
+          ssh -o StrictHostKeyChecking=no "${SSH_USER}@${SSH_HOST}" "mkdir -p /srv/stallapp"
 
-      - name: Upload backend artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-build.zip
-          path: backend/backend-build.zip
+      - name: Sync repository
+        run: |
+          rsync -az --delete \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='vendor' \
+            --exclude='dist' \
+            -e "ssh -o StrictHostKeyChecking=no" \
+            ./ "${SSH_USER}@${SSH_HOST}:/srv/stallapp"
 
-      - name: Package frontend build
-        working-directory: frontend
-        run: zip -r frontend-build.zip dist
-
-      - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-build.zip
-          path: frontend/frontend-build.zip
+      - name: Update application services
+        run: |
+          ssh -o StrictHostKeyChecking=no "${SSH_USER}@${SSH_HOST}" <<'EOSSH'
+          cd /srv/stallapp
+          docker compose pull
+          docker compose up -d --build
+          docker system prune -f
+          EOSSH


### PR DESCRIPTION
## Summary
- replace the deployment workflow with a single deploy job that depends on the CI build
- load the SSH identity, sync the repository to /srv/stallapp, and run docker compose remotely

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c9b4cdf60883248cb67eac46458cb0