### PR TITLE
Add mbstring extension to PHP build image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
     && docker-php-ext-install \
         pdo_pgsql \
         intl \
+        mbstring \
         gd \
         zip \
         sodium \


### PR DESCRIPTION
## Summary
- add the mbstring PHP extension to the backend build image while keeping required dependencies such as oniguruma

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c242c40c8324af3b3fc109733ece