### PR TITLE
Use npm ci in frontend Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install --frozen-lockfile
+RUN npm ci
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- replace the deprecated npm install --frozen-lockfile invocation with npm ci in the frontend Dockerfile to respect package-lock.json
- keep the build step unchanged to continue producing static assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c2a8bbfc8324bcc551200ee34bf0