### PR TITLE
Configure frontend nginx API proxy

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,6 +9,17 @@ server {
         try_files $uri /index.html;
     }
 
+    location /api/ {
+        proxy_pass http://backend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "no-referrer-when-downgrade" always;


### PR DESCRIPTION
## Summary
- add an /api/ location block to the frontend nginx configuration
- forward standard proxy headers and timeouts so API requests reach the backend service

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c8c1692c8324863d9fca865d9ced