### PR TITLE
Simplify supervisord configuration

### DIFF
--- a/backend/docker/supervisord.conf
+++ b/backend/docker/supervisord.conf
@@ -1,23 +1,11 @@
 [supervisord]
-nodaemon=true
-user=root
 
 [program:php-fpm]
-command=/usr/local/sbin/php-fpm --nodaemonize
+command=docker-php-entrypoint php-fpm
 autostart=true
 autorestart=true
-priority=10
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/2
-stderr_logfile_maxbytes=0
 
 [program:nginx]
-command=/usr/sbin/nginx -g "daemon off;"
+command=nginx -g "daemon off;"
 autostart=true
 autorestart=true
-priority=20
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/2
-stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary
- replace the backend Supervisor configuration with the minimal php-fpm and nginx programs required by the container runtime

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cafe85685c8324988ef4e7d67ab77a