### PR TITLE
Update proxy configuration to target backend 8080

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 ## Backend Build & Run
 
-The backend service is built with a multi-stage Dockerfile that compiles application dependencies before producing a lightweight runtime image. The final stage runs PHP-FPM and exposes port 9000 so the proxy container can forward web requests to the PHP application process.
+The backend service is built with a multi-stage Dockerfile that compiles application dependencies before producing a lightweight runtime image. The final stage runs PHP-FPM and exposes port 8080 so the proxy container can forward web requests to the PHP application process.
 
 - Build and start the containers:
   ```sh

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,7 +10,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://backend:80;
+        proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/proxy/vhost.d/app.silent-oak-ranch.de
+++ b/proxy/vhost.d/app.silent-oak-ranch.de
@@ -1,5 +1,5 @@
 location /api {
-    proxy_pass http://backend:8000;
+    proxy_pass http://backend:8080;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- update the nginx-proxy vhost to route API traffic to backend:8080
- update the frontend nginx config so internal API calls target backend:8080
- document the backend's exposed 8080 port in the deployment guide

## Testing
- docker compose up *(fails: `docker` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb02cfe7608324a4bf84d6eec06443