### PR TITLE
Document Docker database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 POSTGRES_USER=stallapp
 POSTGRES_PASSWORD=stallapp123
 POSTGRES_DB=stallapp
+DATABASE_URL=postgresql://stallapp:stallapp123@db:5432/stallapp
 DOMAIN=app.silent-oak-ranch.de
 LETSENCRYPT_EMAIL=info@silent-oak-ranch.de

--- a/README.md
+++ b/README.md
@@ -117,9 +117,13 @@ git push origin v1.0.0
 
 To deploy with Docker Compose:
 
-1. Copy `.env.example` to `.env` and set the domain and email address used for certificates:
+1. Copy `.env.example` to `.env` and review the environment variables consumed by Docker Compose. Adapt the values to your deployment (user, password, database name) and ensure that the `DATABASE_URL` references the `db` service hostname:
 
    ```
+   POSTGRES_USER=stallapp
+   POSTGRES_PASSWORD=stallapp123
+   POSTGRES_DB=stallapp
+   DATABASE_URL=postgresql://stallapp:stallapp123@db:5432/stallapp
    DOMAIN=app.silent-oak-ranch.de
    LETSENCRYPT_EMAIL=info@silent-oak-ranch.de
    ```
@@ -129,6 +133,14 @@ To deploy with Docker Compose:
    ```bash
    docker compose up -d --build
    ```
+
+3. Verify that Symfony can connect to PostgreSQL from inside the backend container:
+
+   ```bash
+   docker compose run --rm backend php bin/console doctrine:query:sql 'SELECT 1'
+   ```
+
+   The command executes a lightweight SQL query via Doctrine and confirms that the configured credentials work end to end.
 
 - All Composer and NPM dependencies are installed automatically during the image build.
 - The frontend is served as an Nginx static server.

--- a/backend/.env
+++ b/backend/.env
@@ -23,8 +23,8 @@ APP_SECRET=
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
+# DATABASE_URL is injected via environment variables in production and container setups.
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data_%kernel.environment%.db"
-DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
 ###< doctrine/doctrine-bundle ###


### PR DESCRIPTION
## Summary
- add a DATABASE_URL entry to the example environment file that targets the docker-compose PostgreSQL service
- remove the hardcoded MySQL DATABASE_URL from the backend defaults and clarify that production relies on real environment variables
- document the required environment variables and the Doctrine connectivity smoke test in the README

## Testing
- docker compose run --rm backend php bin/console doctrine:query:sql 'SELECT 1' *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb056e7d1c8324b6073ce2981e7643