### PR TITLE
Avoid logging DSN credentials in reminders

### DIFF
--- a/backend/src/Service/ReminderService.php
+++ b/backend/src/Service/ReminderService.php
@@ -56,9 +56,9 @@ class ReminderService
 
         $this->logger->info(
             sprintf(
-                'WhatsApp reminder for booking %d would be sent via %s.',
+                'WhatsApp reminder for booking %d (%d h) triggered for sending.',
                 $booking->getId(),
-                $this->whatsappDsn
+                $hoursBefore
             )
         );
     }
@@ -79,9 +79,9 @@ class ReminderService
 
         $this->logger->info(
             sprintf(
-                'SMS reminder for booking %d would be sent via %s.',
+                'SMS reminder for booking %d (%d h) triggered for sending.',
                 $booking->getId(),
-                $this->smsDsn
+                $hoursBefore
             )
         );
     }

--- a/backend/tests/Service/ReminderServiceTest.php
+++ b/backend/tests/Service/ReminderServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Booking;
+use App\Service\ReminderService;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Stringable;
+use Symfony\Component\Mailer\MailerInterface;
+
+class ReminderServiceTest extends TestCase
+{
+    public function testLogsDoNotExposeCredentials(): void
+    {
+        $mailer = $this->createStub(MailerInterface::class);
+        $logger = new CollectingLogger();
+
+        $service = new ReminderService($mailer, $logger, 'whatsapp://user:pass', 'sms://secret');
+        $service->sendReminder($this->createBooking(), 12);
+
+        $messages = array_map(static fn (array $record) => $record['message'], $logger->records);
+
+        $this->assertContains('WhatsApp reminder for booking 42 (12 h) triggered for sending.', $messages);
+        $this->assertContains('SMS reminder for booking 42 (12 h) triggered for sending.', $messages);
+
+        $combinedMessages = implode(' ', $messages);
+        $this->assertStringNotContainsString('whatsapp://user:pass', $combinedMessages);
+        $this->assertStringNotContainsString('sms://secret', $combinedMessages);
+    }
+
+    public function testLogsIndicateMissingCredentials(): void
+    {
+        $mailer = $this->createStub(MailerInterface::class);
+        $logger = new CollectingLogger();
+
+        $service = new ReminderService($mailer, $logger);
+        $service->sendReminder($this->createBooking(), 6);
+
+        $messages = array_map(static fn (array $record) => $record['message'], $logger->records);
+
+        $this->assertContains('WhatsApp reminder for booking 42 (6 h) not sent - no credentials configured.', $messages);
+        $this->assertContains('SMS reminder for booking 42 (6 h) not sent - no credentials configured.', $messages);
+    }
+
+    private function createBooking(): Booking
+    {
+        $booking = new Booking();
+        $booking->setUser('user@example.com');
+        $booking->setLabel('Test Booking');
+        $booking->setStartDate(new DateTimeImmutable('2024-01-01 12:00:00'));
+
+        $idProperty = new \ReflectionProperty(Booking::class, 'id');
+        $idProperty->setAccessible(true);
+        $idProperty->setValue($booking, 42);
+
+        return $booking;
+    }
+}
+
+final class CollectingLogger extends AbstractLogger
+{
+    /** @var list<array{level: string, message: string, context: array}> */
+    public array $records = [];
+
+    /**
+     * @param string $level
+     * @param Stringable|string $message
+     * @param array $context
+     */
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- avoid exposing raw DSN credentials in the reminder service logs and replace them with neutral status messages
- add PHPUnit coverage to ensure reminder logs do not leak credentials and still report missing configuration

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cb0cd6b9048324b79a76afca25fbac