### PR TITLE
Add build stage to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  build:
+    name: Build Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build application images
+        env:
+          COMPOSE_PROJECT_NAME: stallapp
+        run: docker compose build backend frontend
+
+      - name: Export Docker images
+        run: |
+          mkdir -p docker-images
+          docker save silentoakranch/backend:latest -o docker-images/backend.tar
+          docker save silentoakranch/frontend:latest -o docker-images/frontend.tar
+
+      - name: Upload Docker images
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-images
+          path: docker-images/
+          if-no-files-found: error
+
   deploy:
     name: Deploy application
     runs-on: ubuntu-latest
@@ -16,6 +43,12 @@ jobs:
       SSH_HOST: ${{ secrets.SSH_HOST }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download Docker images
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-images
+          path: docker-images
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -39,8 +72,15 @@ jobs:
       - name: Update application services
         run: |
           ssh -o StrictHostKeyChecking=no "${SSH_USER}@${SSH_HOST}" <<'EOSSH'
+          set -euo pipefail
           cd /srv/stallapp
-          docker compose pull
-          docker compose up -d --build
+          if ls docker-images/*.tar >/dev/null 2>&1; then
+            for archive in docker-images/*.tar; do
+              docker load -i "$archive"
+            done
+            rm -f docker-images/*.tar
+          fi
+          docker compose pull db proxy letsencrypt || true
+          docker compose up -d
           docker system prune -f
           EOSSH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ./db/data:/var/lib/postgresql/data
 
   backend:
+    image: silentoakranch/backend:latest
     build: ./backend
     env_file: .env
     depends_on:
@@ -21,6 +22,7 @@ services:
       LETSENCRYPT_EMAIL: "${LETSENCRYPT_EMAIL}"
 
   frontend:
+    image: silentoakranch/frontend:latest
     build: ./frontend
     expose:
       - "80"


### PR DESCRIPTION
## Summary
- add a build job to the deploy workflow that builds the backend and frontend images and publishes them as artifacts
- update the deploy job to download the images, load them on the target host, and refresh the stack without rebuilding
- assign explicit image names in docker-compose so the pre-built images are used consistently during deployment

## Testing
- not run (Docker/`act` not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb0cde126c8324b46a3749ca755681