### PR TITLE
Adjust backend proxy metadata

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,8 @@ services:
     expose:
       - "8080"
     environment:
-      VIRTUAL_HOST: "${DOMAIN}"
+      VIRTUAL_PATH: "/api"
       VIRTUAL_PORT: "8080"
-      LETSENCRYPT_HOST: "${DOMAIN}"
-      LETSENCRYPT_EMAIL: "${LETSENCRYPT_EMAIL}"
     volumes:
       - ./shared/jwt/backend:/var/www/backend/config/jwt
 


### PR DESCRIPTION
## Summary
- update the backend service proxy metadata to use `VIRTUAL_PATH=/api`
- remove redundant Let's Encrypt variables that duplicated the frontend domain configuration

## Testing
- docker compose up -d --build backend *(fails: `docker` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb270503c48324ae70656cf7c91b05