### PR TITLE
Adjust proxy routing for API path prefix

### DIFF
--- a/proxy/vhost.d/app.silent-oak-ranch.de
+++ b/proxy/vhost.d/app.silent-oak-ranch.de
@@ -1,9 +1,13 @@
-location /api {
+location ^~ /api/ {
     proxy_pass http://backend:8080;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Prefix /api;
 }
+
 location / {
     proxy_pass http://frontend:80;
 }


### PR DESCRIPTION
## Summary
- update the API location block to use a prefix match and forward X-Forwarded headers expected by the backend
- continue routing all other traffic through the frontend container

## Testing
- docker compose exec proxy nginx -s reload *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb27924d20832493001c6769798c32