### PR TITLE
Add health check endpoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -80,6 +80,6 @@ RUN cp /docker/app.conf /etc/nginx/conf.d/app.conf \
 COPY --from=production /var/www/backend /var/www/backend
 
 EXPOSE 8080
-HEALTHCHECK CMD curl -fsS http://127.0.0.1:8080/ || exit 1
+HEALTHCHECK CMD curl -fsS http://127.0.0.1:8080/healthz || exit 1
 ENTRYPOINT ["/docker/entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -27,6 +27,7 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+        - { path: ^/healthz, roles: PUBLIC_ACCESS }
         - { path: ^/api/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/register, roles: PUBLIC_ACCESS }
         - { path: ^/api/invite, roles: ROLE_ADMIN }

--- a/backend/src/Controller/HealthCheckController.php
+++ b/backend/src/Controller/HealthCheckController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+class HealthCheckController
+{
+    #[Route('/healthz', name: 'health_check', methods: ['GET'])]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse(['status' => 'ok']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight health check controller that returns a JSON payload
- allow anonymous access to the /healthz endpoint in the security configuration
- update the backend image health check to hit the new endpoint

## Testing
- php -l backend/src/Controller/HealthCheckController.php
- docker compose build backend *(fails: docker CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2a123ea8832497cfee86de6b28ee