### PR TITLE
Configure trusted proxy settings via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ APP_SECRET=generate-a-64-char-random-value
 # === Domain & TLS ===
 DOMAIN=app.example.com
 LETSENCRYPT_EMAIL=admin@example.com
+TRUSTED_PROXIES=0.0.0.0/0
+TRUSTED_HOSTS=^app\\.example\\.com$
 
 # === Stripe ===
 STRIPE_SECRET_KEY=sk_live_replace-me

--- a/backend/config/packages/framework.yaml
+++ b/backend/config/packages/framework.yaml
@@ -2,6 +2,9 @@
 framework:
     secret: '%env(APP_SECRET)%'
     default_locale: 'de'
+    trusted_proxies: '%env(default::TRUSTED_PROXIES)%'
+    trusted_hosts:
+        - '%env(default::TRUSTED_HOSTS)%'
 
     # Note that the session will be started ONLY if you read or write from it.
     session: true

--- a/backend/tests/TrustedForwardedHeaderTest.php
+++ b/backend/tests/TrustedForwardedHeaderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TrustedForwardedHeaderTest extends WebTestCase
+{
+    private bool $trustedProxiesWasSet;
+    private ?string $trustedProxiesPrevious;
+    private bool $trustedHostsWasSet;
+    private ?string $trustedHostsPrevious;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        [$this->trustedProxiesWasSet, $this->trustedProxiesPrevious] = $this->captureEnv('TRUSTED_PROXIES');
+        [$this->trustedHostsWasSet, $this->trustedHostsPrevious] = $this->captureEnv('TRUSTED_HOSTS');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreEnv('TRUSTED_PROXIES', $this->trustedProxiesPrevious, $this->trustedProxiesWasSet);
+        $this->restoreEnv('TRUSTED_HOSTS', $this->trustedHostsPrevious, $this->trustedHostsWasSet);
+
+        parent::tearDown();
+    }
+
+    public function testForwardedProtoMarksRequestAsSecure(): void
+    {
+        $this->setEnv('TRUSTED_PROXIES', '127.0.0.1');
+        $this->setEnv('TRUSTED_HOSTS', '^localhost$');
+
+        static::ensureKernelShutdown();
+
+        $client = static::createClient(server: [
+            'HTTP_HOST' => 'localhost',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'HTTP_X_FORWARDED_PORT' => '443',
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.24',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ]);
+
+        $client->request('GET', '/healthz');
+
+        self::assertSame(200, $client->getResponse()->getStatusCode());
+        self::assertSame('https', $client->getRequest()->getScheme());
+        self::assertTrue($client->getRequest()->isSecure());
+    }
+
+    private function captureEnv(string $name): array
+    {
+        $value = getenv($name);
+
+        if (false === $value) {
+            return [false, null];
+        }
+
+        return [true, $value];
+    }
+
+    private function setEnv(string $name, string $value): void
+    {
+        putenv(sprintf('%s=%s', $name, $value));
+        $_ENV[$name] = $value;
+        $_SERVER[$name] = $value;
+    }
+
+    private function restoreEnv(string $name, ?string $value, bool $wasSet): void
+    {
+        if ($wasSet) {
+            putenv(sprintf('%s=%s', $name, $value));
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+
+            return;
+        }
+
+        putenv($name);
+        unset($_ENV[$name], $_SERVER[$name]);
+    }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,21 @@ The backend service is built with a multi-stage Dockerfile that compiles applica
   docker compose exec backend php bin/console doctrine:migrations:migrate --no-interaction
   ```
 
+### Reverse proxy headers
+
+If the application is deployed behind a load balancer or ingress controller, configure
+trusted proxies and hosts via environment variables so Symfony can rely on forwarded
+headers for the original request metadata:
+
+```bash
+TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16
+TRUSTED_HOSTS=^app\\.example\\.com$,^api\\.example\\.com$
+```
+
+The proxy list accepts comma-separated CIDR ranges or IP addresses, and host patterns use
+regular expressions. These values ensure HTTPS detection and host validation work correctly
+once the app runs behind the proxy tier.
+
 ## Frontend Build & Run
 
 The frontend is containerized with a multi-stage Dockerfile.


### PR DESCRIPTION
## Summary
- allow configuring Symfony trusted proxies and hosts through the `TRUSTED_PROXIES` and `TRUSTED_HOSTS` environment variables
- surface the new variables in the shared `.env.example` and document them in the deployment guide
- add a functional test to ensure forwarded HTTPS headers are honoured when proxies are trusted

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68cb2ede0cec8324a573abf2588d9d5d