### PR TITLE
Update CI to PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - name: Validate Composer configuration
         run: composer validate

--- a/backend/src/Service/ScaleBookingService.php
+++ b/backend/src/Service/ScaleBookingService.php
@@ -79,6 +79,17 @@ class ScaleBookingService
 
     /**
      * Creates a normalized payload for API responses including a QR code image.
+     *
+     * @return array{
+     *     id: string,
+     *     horse: array{name: string},
+     *     slot: string,
+     *     status: string,
+     *     price: string,
+     *     weight: float|null,
+     *     qrToken: string,
+     *     qrImage: string,
+     * }
      */
     public function serializeBooking(ScaleBooking $booking): array
     {


### PR DESCRIPTION
## Summary
- bump the CI workflow to run PHP 8.3 via `shivammathur/setup-php`
- add an array shape annotation for `ScaleBookingService::serializeBooking()` so phpstan stays clean

## Testing
- composer validate (backend)
- vendor/bin/phpstan analyse (backend)
- vendor/bin/phpunit --testdox (backend)
- npm ci (frontend)
- npm run lint (frontend)
- npm test (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cb86198f508324a251bb134c442d8e