### PR TITLE
Update documentation for PHP 8.3 stack and env configuration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,12 +14,22 @@ composer install --ignore-platform-req=ext-sodium
 
 ## Datenbank
 
-Standardmäßig wird eine SQLite-Datenbank verwendet. Die Verbindungszeichenfolge
-ist in `.env` hinterlegt und lautet:
+Standardmäßig wird eine PostgreSQL-Datenbank verwendet – exakt so, wie es in
+`.env.example` vorkonfiguriert ist:
 
 ```text
-DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
+DATABASE_URL="postgresql://your-db-user:your-db-password@db:5432/your-db-name"
 ```
 
-Die Datei `var/data.db` befindet sich im Projektverzeichnis und wird
-automatisch angelegt, falls sie nicht existiert.
+Zusätzlich lesen die Container die Werte `POSTGRES_USER`, `POSTGRES_PASSWORD`
+und `POSTGRES_DB` aus derselben `.env` Datei. Im Docker-Setup erreicht Symfony
+die Datenbank über den Host `db` und Port `5432`. Passe die Variablen bei
+lokalen Installationen entsprechend an oder verknüpfe sie mit einem externen
+PostgreSQL-Server.
+
+Nach dem Start der Container (`docker compose up`) können Doctrine-Migrationen
+ausgeführt werden, zum Beispiel:
+
+```bash
+docker compose run --rm backend php bin/console doctrine:migrations:migrate --no-interaction
+```


### PR DESCRIPTION
## Summary
- document the PHP 8.3-based Docker stack and CI/CD workflows in the root README
- add guidance for creating the project-wide `.env` file and populating required variables
- describe the PostgreSQL default database configuration in `backend/README.md`

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cb8e88656c83249d6ccc2ef3d9d149