### PR TITLE
Configure ACME companion to locate proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To deploy with Docker Compose manually:
 - All Composer and NPM dependencies are installed automatically during the image build.
 - The frontend is served as an Nginx static server.
 
-The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt. The proxy routes requests based on the path:
+The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt. Ensure the companion sees the proxy by exporting `NGINX_PROXY_CONTAINER=proxy` (as done in `docker-compose.yml`) or by giving the proxy container that name before starting the stack; otherwise certificate discovery fails. The proxy routes requests based on the path:
 
 - https://app.silent-oak-ranch.de → Frontend (Port 80)
 - https://app.silent-oak-ranch.de/api → Backend (Port 8080)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,8 @@ services:
       - proxy
     volumes_from:
       - proxy
+    environment:
+      NGINX_PROXY_CONTAINER: "proxy"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./proxy/certs:/etc/nginx/certs:rw


### PR DESCRIPTION
## Summary
- set `NGINX_PROXY_CONTAINER=proxy` for the letsencrypt service so the ACME companion locates the nginx-proxy container
- document the proxy container naming requirement in the deployment guide to keep certificate issuance working

## Testing
- ⚠️ `docker compose up -d --build` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbddcc26d483248aff7443f183e009