### PR TITLE
Configure Stripe client with API key and add integration test

### DIFF
--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -18,7 +18,8 @@ services:
 
     Stripe\StripeClient:
         arguments:
-            $config: '%env(STRIPE_SECRET_KEY)%'
+            $config:
+                api_key: '%env(STRIPE_SECRET_KEY)%'
 
     App\Service\AvailabilityService:
         arguments:

--- a/backend/tests/Service/StripeServiceTest.php
+++ b/backend/tests/Service/StripeServiceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\StripeService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class StripeServiceTest extends KernelTestCase
+{
+    public function testCreatePaymentIntentWithConfiguredApiKey(): void
+    {
+        $apiKey = $_ENV['STRIPE_SECRET_KEY']
+            ?? $_SERVER['STRIPE_SECRET_KEY']
+            ?? getenv('STRIPE_SECRET_KEY');
+
+        if (empty($apiKey) || str_contains((string) $apiKey, 'replace-me')) {
+            self::markTestSkipped('No Stripe API key configured for integration testing.');
+        }
+
+        self::bootKernel();
+
+        /** @var StripeService $service */
+        $service = self::getContainer()->get(StripeService::class);
+
+        $intent = $service->createPaymentIntent(123, 'usd', [
+            'test_case' => static::class,
+            'created_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ]);
+
+        self::assertSame(123, $intent->amount);
+        self::assertSame('usd', $intent->currency);
+        self::assertNotEmpty($intent->id);
+        self::assertSame(static::class, $intent->metadata['test_case']);
+    }
+}


### PR DESCRIPTION
## Summary
- inject the Stripe API key into the StripeClient service configuration so authenticated requests succeed
- add a StripeService integration test that creates a PaymentIntent when a real API key is configured

## Testing
- vendor/bin/phpstan analyse
- ./bin/phpunit --testdox

------
https://chatgpt.com/codex/tasks/task_e_68cbe15f8e4c8324b5f62fe8b5660981