### PR TITLE
Align Stripe checkout integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ TRUSTED_HOSTS=^app\\.example\\.com$
 
 # === Stripe ===
 STRIPE_SECRET_KEY=sk_live_replace-me
+VITE_STRIPE_PUBLISHABLE_KEY=pk_live_replace-me
 
 # === JWT authentication ===
 JWT_SECRET_KEY=/var/www/backend/config/jwt/private.pem

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Populate every mandatory entry from `.env.example`:
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `DATABASE_URL` – configure the PostgreSQL 15 service that the backend reaches via the internal host `db:5432`.
 - `APP_ENV`, `APP_SECRET` – choose the Symfony environment (`dev` for local, `prod` for deployments) and generate a 64-character secret, e.g. `php -r 'echo bin2hex(random_bytes(32));'`.
 - `DOMAIN`, `LETSENCRYPT_EMAIL`, `TRUSTED_PROXIES`, `TRUSTED_HOSTS` – define the public hostname and proxy settings consumed by the nginx-proxy and Let's Encrypt companion containers.
-- `STRIPE_SECRET_KEY` – supply the live Stripe API key used during checkout.
+- `STRIPE_SECRET_KEY`, `VITE_STRIPE_PUBLISHABLE_KEY` – supply the backend secret key and frontend publishable key used during Stripe Checkout.
 - `JWT_SECRET_KEY`, `JWT_PUBLIC_KEY`, `JWT_PASSPHRASE` – point to the LexikJWT key pair and provide the matching passphrase (generate the keys with `docker compose run --rm backend php bin/console lexik:jwt:generate-keypair --overwrite`).
 - `MESSENGER_TRANSPORT_DSN`, `WHATSAPP_DSN`, `SMS_DSN` – configure the messenger transports for asynchronous processing and notifications.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD` – configure outbound mail delivery.

--- a/backend/src/Controller/StripeWebhookController.php
+++ b/backend/src/Controller/StripeWebhookController.php
@@ -16,17 +16,50 @@ class StripeWebhookController extends AbstractController
     {
     }
     #[Route('/api/bookings/{id}/pay', name: 'api_booking_pay', methods: ['POST'])]
-    public function pay(int $id, BookingRepository $bookingRepository, StripeService $stripeService): JsonResponse
-    {
+    public function pay(
+        int $id,
+        Request $request,
+        BookingRepository $bookingRepository,
+        StripeService $stripeService
+    ): JsonResponse {
         $booking = $bookingRepository->find($id);
         if (!$booking) {
             return $this->json(['message' => $this->translator->trans('Booking not found', [], 'validators')], 404);
         }
 
-        $amount = (int) (floatval($booking->getPrice()) * 100);
-        $intent = $stripeService->createPaymentIntent($amount, 'usd', ['booking_id' => $id]);
+        try {
+            $payload = $request->toArray();
+        } catch (\JsonException) {
+            return $this->json(['message' => $this->translator->trans('Invalid payload', [], 'validators')], 400);
+        }
 
-        return $this->json(['clientSecret' => $intent->client_secret]);
+        $successUrl = $payload['successUrl'] ?? null;
+        $cancelUrl = $payload['cancelUrl'] ?? null;
+
+        if (!is_string($successUrl) || !filter_var($successUrl, FILTER_VALIDATE_URL)) {
+            return $this->json(['message' => $this->translator->trans('Invalid payload', [], 'validators')], 400);
+        }
+
+        if (!is_string($cancelUrl) || !filter_var($cancelUrl, FILTER_VALIDATE_URL)) {
+            return $this->json(['message' => $this->translator->trans('Invalid payload', [], 'validators')], 400);
+        }
+
+        $amount = (int) round(((float) $booking->getPrice()) * 100);
+        if ($amount <= 0) {
+            return $this->json(['message' => $this->translator->trans('Invalid booking price', [], 'validators')], 400);
+        }
+
+        $session = $stripeService->createCheckoutSession(
+            $amount,
+            'usd',
+            $successUrl,
+            $cancelUrl,
+            $booking->getLabel(),
+            ['booking_id' => (string) $booking->getId()],
+            $booking->getUser()
+        );
+
+        return $this->json(['sessionId' => $session->id]);
     }
 
     #[Route('/api/stripe/webhook', name: 'api_stripe_webhook', methods: ['POST'])]

--- a/backend/src/Service/StripeService.php
+++ b/backend/src/Service/StripeService.php
@@ -19,6 +19,48 @@ class StripeService
         ]);
     }
 
+    public function createCheckoutSession(
+        int $amount,
+        string $currency,
+        string $successUrl,
+        string $cancelUrl,
+        string $description,
+        array $metadata = [],
+        ?string $customerEmail = null
+    ): \Stripe\Checkout\Session {
+        $normalizedMetadata = array_map(static fn($value) => (string) $value, $metadata);
+
+        $payload = [
+            'mode' => 'payment',
+            'success_url' => $successUrl,
+            'cancel_url' => $cancelUrl,
+            'line_items' => [[
+                'price_data' => [
+                    'currency' => $currency,
+                    'unit_amount' => $amount,
+                    'product_data' => [
+                        'name' => $description !== '' ? $description : 'Booking payment',
+                    ],
+                ],
+                'quantity' => 1,
+            ]],
+            'metadata' => $normalizedMetadata,
+            'payment_intent_data' => [
+                'metadata' => $normalizedMetadata,
+            ],
+        ];
+
+        if (!empty($normalizedMetadata['booking_id'])) {
+            $payload['client_reference_id'] = $normalizedMetadata['booking_id'];
+        }
+
+        if ($customerEmail !== null) {
+            $payload['customer_email'] = $customerEmail;
+        }
+
+        return $this->client->checkout->sessions->create($payload);
+    }
+
     public function createInvoiceDraft(string $customerId, array $params = []): \Stripe\Invoice
     {
         return $this->client->invoices->create(array_merge([

--- a/backend/tests/Service/StripeServiceTest.php
+++ b/backend/tests/Service/StripeServiceTest.php
@@ -9,13 +9,7 @@ class StripeServiceTest extends KernelTestCase
 {
     public function testCreatePaymentIntentWithConfiguredApiKey(): void
     {
-        $apiKey = $_ENV['STRIPE_SECRET_KEY']
-            ?? $_SERVER['STRIPE_SECRET_KEY']
-            ?? getenv('STRIPE_SECRET_KEY');
-
-        if (empty($apiKey) || str_contains((string) $apiKey, 'replace-me')) {
-            self::markTestSkipped('No Stripe API key configured for integration testing.');
-        }
+        $this->ensureStripeApiKeyOrSkip();
 
         self::bootKernel();
 
@@ -31,5 +25,45 @@ class StripeServiceTest extends KernelTestCase
         self::assertSame('usd', $intent->currency);
         self::assertNotEmpty($intent->id);
         self::assertSame(static::class, $intent->metadata['test_case']);
+    }
+
+    public function testCreateCheckoutSessionWithConfiguredApiKey(): void
+    {
+        $this->ensureStripeApiKeyOrSkip();
+
+        self::bootKernel();
+
+        /** @var StripeService $service */
+        $service = self::getContainer()->get(StripeService::class);
+
+        $session = $service->createCheckoutSession(
+            123,
+            'usd',
+            'https://example.com/success',
+            'https://example.com/cancel',
+            'Test checkout session',
+            [
+                'booking_id' => 'test-checkout',
+                'test_case' => static::class,
+            ],
+            'customer@example.com'
+        );
+
+        self::assertNotEmpty($session->id);
+        self::assertSame('payment', $session->mode);
+        self::assertSame('https://example.com/success', $session->success_url);
+        self::assertSame('https://example.com/cancel', $session->cancel_url);
+        self::assertSame('test-checkout', $session->client_reference_id);
+    }
+
+    private function ensureStripeApiKeyOrSkip(): void
+    {
+        $apiKey = $_ENV['STRIPE_SECRET_KEY']
+            ?? $_SERVER['STRIPE_SECRET_KEY']
+            ?? getenv('STRIPE_SECRET_KEY');
+
+        if (empty($apiKey) || str_contains((string) $apiKey, 'replace-me')) {
+            self::markTestSkipped('No Stripe API key configured for integration testing.');
+        }
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.21.2"
       },
       "devDependencies": {
+        "@eslint/js": "^9.35.0",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.21.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.35.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.2.21",

--- a/frontend/src/modules/bookings/PaymentButton.tsx
+++ b/frontend/src/modules/bookings/PaymentButton.tsx
@@ -1,19 +1,52 @@
-import { loadStripe } from '@stripe/stripe-js'
+import { loadStripe, Stripe } from '@stripe/stripe-js'
 import api from '../../axios'
 
-const stripePromise = loadStripe('pk_test_12345')
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+
+const stripePromise: Promise<Stripe | null> = publishableKey
+  ? loadStripe(publishableKey)
+  : Promise.resolve<Stripe | null>(null)
+
+type PayResponse = {
+  sessionId: string
+}
 
 function PaymentButton({ bookingId }: { bookingId: number }) {
   async function handlePay() {
     const stripe = await stripePromise
-    if (!stripe) return
-    const res = await api.post(`/bookings/${bookingId}/pay`)
-    const { clientSecret } = res.data
-    await stripe.redirectToCheckout({ sessionId: clientSecret })
+    if (!stripe) {
+      console.error('Stripe publishable key is not configured.')
+      return
+    }
+
+    try {
+      const origin = window.location.origin
+      const response = await api.post<PayResponse>(`/bookings/${bookingId}/pay`, {
+        successUrl: `${origin}/bookings?payment=success`,
+        cancelUrl: `${origin}/bookings?payment=cancel`,
+      })
+
+      const { sessionId } = response.data
+      if (!sessionId) {
+        throw new Error('Missing session ID from payment endpoint response.')
+      }
+
+      const { error } = await stripe.redirectToCheckout({ sessionId })
+      if (error) {
+        console.error('Stripe Checkout redirect failed.', error)
+      }
+    } catch (error) {
+      console.error('Unable to start the Stripe Checkout session.', error)
+    }
   }
 
   return (
-    <button onClick={handlePay} className="bg-green-500 text-white px-4 py-2">
+    <button
+      onClick={handlePay}
+      className="bg-green-500 text-white px-4 py-2"
+      disabled={!publishableKey}
+      title={publishableKey ? undefined : 'Stripe publishable key missing'}
+    >
       Pay
     </button>
   )


### PR DESCRIPTION
## Summary
- load the Stripe publishable key from `import.meta.env` in the booking payment button and start Checkout sessions with the returned session ID
- update the backend payment endpoint to create Stripe Checkout sessions via a new service helper and align the service tests
- document the frontend publishable key in `.env.example`/README and add the missing ESLint dependency required by the existing config

## Testing
- npm run lint
- npm test
- npm run build
- (cd backend && ./bin/phpunit --testdox)


------
https://chatgpt.com/codex/tasks/task_e_68cbeabadf78832489b2de5fd9f36e9c