### PR TITLE
Align appointments frontend with API service data

### DIFF
--- a/frontend/src/__tests__/appointments/AppointmentAdmin.test.tsx
+++ b/frontend/src/__tests__/appointments/AppointmentAdmin.test.tsx
@@ -44,10 +44,13 @@ describe('AppointmentAdmin', () => {
     const appointments = [
       {
         id: 1,
+        horse: { id: 1, name: 'Star' },
+        owner: { id: 1, name: 'Rider' },
         provider: { id: 1, name: 'Vet' },
         serviceType: { id: 1, name: 'Checkup' },
         start: '2024-01-01T10:00:00Z',
-        status: 'pending',
+        end: '2024-01-01T11:00:00Z',
+        status: 'requested',
       },
     ]
     const state = {

--- a/frontend/src/__tests__/appointments/AppointmentForm.test.tsx
+++ b/frontend/src/__tests__/appointments/AppointmentForm.test.tsx
@@ -36,36 +36,29 @@ describe('AppointmentForm', () => {
     expect(dispatch.mock.calls.length).toBe(initialCalls)
   })
 
-  it('shows only available slots to prevent collisions', () => {
-    const available = {
-      id: 1,
-      start: '2024-01-01T10:00:00Z',
-      status: 'available',
-      provider: { id: 1, name: 'Vet' },
-      serviceType: { id: 1, name: 'Checkup' },
-    }
-    const booked = {
-      id: 2,
-      start: '2024-01-01T11:00:00Z',
-      status: 'booked',
-      provider: { id: 1, name: 'Vet' },
-      serviceType: { id: 1, name: 'Checkup' },
-    }
+  it('prefills the end time based on the selected service duration', () => {
     const state = {
       appointments: {
         providers: [{ id: 1, name: 'Vet' }],
-        serviceTypes: [{ id: 1, name: 'Checkup' }],
-        appointments: [available, booked],
+        serviceTypes: [
+          { id: 1, name: 'Checkup', defaultDurationMinutes: 60 },
+          { id: 2, name: 'Short', defaultDurationMinutes: 15 },
+        ],
+        appointments: [],
       },
     }
     const store = { getState: () => state, dispatch: vi.fn(), subscribe: vi.fn() }
 
     render(createElement(Provider, { store }, createElement(AppointmentForm)))
 
-    const slotSelect = screen.getAllByRole('combobox')[2] as HTMLSelectElement
-    const options = Array.from(slotSelect.querySelectorAll('option'))
-    expect(options.length).toBe(2)
-    expect(options[1].value).toBe(available.start)
+    const [, serviceTypeSelect] = screen.getAllByRole('combobox') as HTMLSelectElement[]
+    fireEvent.change(serviceTypeSelect, { target: { value: '1' } })
+
+    const startInput = screen.getByLabelText('appointments.slot') as HTMLInputElement
+    fireEvent.change(startInput, { target: { value: '2024-01-01T10:00' } })
+
+    const endInput = screen.getByLabelText('appointments.end_time') as HTMLInputElement
+    expect(endInput.value).toBe('2024-01-01T11:00')
   })
 })
 

--- a/frontend/src/api/appointments.ts
+++ b/frontend/src/api/appointments.ts
@@ -3,63 +3,167 @@ import api from '../axios'
 export interface Provider {
   id: number
   name: string
+  type?: string
+  contact?: string | null
+  notes?: string | null
+  active?: boolean
 }
 
 export interface ServiceType {
+  id: number
+  name: string
+  providerType?: string
+  defaultDurationMinutes?: number
+  basePrice?: number
+  taxable?: boolean
+}
+
+export interface HorseSummary {
+  id: number
+  name: string
+}
+
+export interface OwnerSummary {
   id: number
   name: string
 }
 
 export interface Appointment {
   id: number
-  provider: Provider
+  horse: HorseSummary
+  owner: OwnerSummary
+  provider: Provider | null
   serviceType: ServiceType
   start: string
+  end: string
   status: string
-  notes?: string
-  reminderOptIn?: boolean
+  price?: number | null
+  notes?: string | null
 }
 
 export interface CreateAppointmentPayload {
-  providerId: number
   serviceTypeId: number
   start: string
+  end: string
+  providerId?: number
+  horseId?: number
   notes?: string
   reminderOptIn?: boolean
 }
 
+type ProviderResponse = {
+  id: number
+  name: string
+  type?: string
+  contact?: string | null
+  notes?: string | null
+  active?: boolean
+}
+
+type ServiceTypeResponse = {
+  id: number
+  name: string
+  providerType?: string
+  defaultDurationMinutes?: number
+  basePrice?: number
+  taxable?: boolean
+}
+
+type AppointmentResponse = {
+  id: number
+  horse: HorseSummary
+  owner: OwnerSummary
+  serviceProvider: ProviderResponse | null
+  serviceType: ServiceTypeResponse
+  startTime: string
+  endTime: string
+  status: string
+  price?: number | null
+  notes?: string | null
+}
+
+const mapProvider = (provider: ProviderResponse): Provider => ({
+  id: provider.id,
+  name: provider.name,
+  type: provider.type,
+  contact: provider.contact ?? null,
+  notes: provider.notes ?? null,
+  active: provider.active,
+})
+
+const mapServiceType = (type: ServiceTypeResponse): ServiceType => ({
+  id: type.id,
+  name: type.name,
+  providerType: type.providerType,
+  defaultDurationMinutes: type.defaultDurationMinutes,
+  basePrice: type.basePrice,
+  taxable: type.taxable,
+})
+
+const mapAppointment = (appointment: AppointmentResponse): Appointment => ({
+  id: appointment.id,
+  horse: appointment.horse,
+  owner: appointment.owner,
+  provider: appointment.serviceProvider ? mapProvider(appointment.serviceProvider) : null,
+  serviceType: mapServiceType(appointment.serviceType),
+  start: appointment.startTime,
+  end: appointment.endTime,
+  status: appointment.status,
+  price: appointment.price ?? null,
+  notes: appointment.notes ?? null,
+})
+
 export async function getProviders() {
-  const res = await api.get<Provider[]>('/appointments/providers')
-  return res.data
+  const res = await api.get<ProviderResponse[]>('/service-providers')
+  return res.data.map(mapProvider)
 }
 
 export async function getServiceTypes() {
-  const res = await api.get<ServiceType[]>('/appointments/service-types')
-  return res.data
+  const res = await api.get<ServiceTypeResponse[]>('/service-types')
+  return res.data.map(mapServiceType)
 }
 
 export async function getAppointments() {
-  const res = await api.get<Appointment[]>('/appointments')
-  return res.data
+  const res = await api.get<AppointmentResponse[]>('/appointments')
+  return res.data.map(mapAppointment)
 }
 
 export async function createAppointment(payload: CreateAppointmentPayload) {
-  const res = await api.post<Appointment>('/appointments', payload)
-  return res.data
+  const body: Record<string, unknown> = {
+    serviceTypeId: payload.serviceTypeId,
+    startTime: payload.start,
+    endTime: payload.end,
+  }
+
+  if (payload.providerId !== undefined) {
+    body.serviceProviderId = payload.providerId
+  }
+  if (payload.horseId !== undefined) {
+    body.horseId = payload.horseId
+  }
+  if (payload.notes !== undefined) {
+    body.notes = payload.notes
+  }
+  if (payload.reminderOptIn !== undefined) {
+    body.reminderOptIn = payload.reminderOptIn
+  }
+
+  const res = await api.post<AppointmentResponse>('/appointments', body)
+  return mapAppointment(res.data)
 }
 
 export async function confirmAppointment(id: number) {
-  const res = await api.post<Appointment>(`/appointments/${id}/confirm`)
-  return res.data
+  const res = await api.post<AppointmentResponse>(`/appointments/${id}/confirm`)
+  return mapAppointment(res.data)
 }
 
 export async function completeAppointment(id: number) {
-  const res = await api.post<Appointment>(`/appointments/${id}/complete`)
-  return res.data
+  const res = await api.post<AppointmentResponse>(`/appointments/${id}/complete`)
+  return mapAppointment(res.data)
 }
 
 export async function cancelAppointment(id: number) {
-  const res = await api.post<Appointment>(`/appointments/${id}/cancel`)
-  return res.data
+  const res = await api.post<AppointmentResponse>(`/appointments/${id}/cancel`)
+  return mapAppointment(res.data)
 }
 

--- a/frontend/src/modules/appointments/AppointmentAdmin.tsx
+++ b/frontend/src/modules/appointments/AppointmentAdmin.tsx
@@ -28,11 +28,15 @@ function AppointmentAdmin() {
     dispatch(loadAppointments())
   }, [dispatch])
 
-  const filtered = appointments.filter(
-    a =>
-      (providerFilter ? a.provider.id === parseInt(providerFilter, 10) : true) &&
-      (serviceFilter ? a.serviceType.id === parseInt(serviceFilter, 10) : true)
-  )
+  const filtered = appointments.filter(a => {
+    const providerMatches = providerFilter
+      ? a.provider?.id === parseInt(providerFilter, 10)
+      : true
+    const serviceMatches = serviceFilter
+      ? a.serviceType.id === parseInt(serviceFilter, 10)
+      : true
+    return providerMatches && serviceMatches
+  })
 
   return (
     <div className="p-4">
@@ -77,7 +81,7 @@ function AppointmentAdmin() {
           {filtered.map(a => (
             <tr key={a.id} className="text-center">
               <td className="border p-2">{new Date(a.start).toLocaleString()}</td>
-              <td className="border p-2">{a.provider.name}</td>
+              <td className="border p-2">{a.provider?.name ?? '-'}</td>
               <td className="border p-2">{a.serviceType.name}</td>
               <td className="border p-2">{a.status}</td>
               <td className="border p-2 space-x-2">

--- a/frontend/src/modules/appointments/AppointmentForm.tsx
+++ b/frontend/src/modules/appointments/AppointmentForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from '../../store'
@@ -12,6 +12,15 @@ import {
   selectServiceTypes,
 } from '../../store/appointmentsSlice'
 
+function formatForDateTimeLocal(date: Date) {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  const hours = `${date.getHours()}`.padStart(2, '0')
+  const minutes = `${date.getMinutes()}`.padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
 function AppointmentForm() {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
@@ -21,6 +30,8 @@ function AppointmentForm() {
   const [providerId, setProviderId] = useState('')
   const [serviceTypeId, setServiceTypeId] = useState('')
   const [start, setStart] = useState('')
+  const [end, setEnd] = useState('')
+  const [userEditedEnd, setUserEditedEnd] = useState(false)
   const [notes, setNotes] = useState('')
   const [reminder, setReminder] = useState(false)
   const { t } = useTranslation()
@@ -31,24 +42,89 @@ function AppointmentForm() {
     dispatch(loadAppointments())
   }, [dispatch])
 
-  const availableSlots = appointments.filter(a => a.status === 'available')
+  const selectedServiceType = useMemo(() => {
+    const id = Number.parseInt(serviceTypeId, 10)
+    if (Number.isNaN(id)) return undefined
+    return serviceTypes.find(s => s.id === id)
+  }, [serviceTypeId, serviceTypes])
+
+  useEffect(() => {
+    setUserEditedEnd(false)
+  }, [serviceTypeId])
+
+  useEffect(() => {
+    if (!start) {
+      setEnd('')
+    }
+  }, [start])
+
+  useEffect(() => {
+    if (!start) {
+      return
+    }
+    const duration = selectedServiceType?.defaultDurationMinutes
+    if (!duration || userEditedEnd) {
+      return
+    }
+
+    const startDate = new Date(start)
+    if (Number.isNaN(startDate.getTime())) {
+      return
+    }
+    const endDate = new Date(startDate.getTime() + duration * 60 * 1000)
+    setEnd(formatForDateTimeLocal(endDate))
+  }, [start, selectedServiceType, userEditedEnd])
+
+  const activeAppointments = useMemo(
+    () => appointments.filter(a => a.status !== 'canceled'),
+    [appointments]
+  )
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!providerId || !serviceTypeId || !start) {
+    if (!providerId || !serviceTypeId || !start || !end) {
       return
     }
-    const collision = appointments.some(
-      a => a.start === start && a.status !== 'available'
-    )
+    const provider = Number.parseInt(providerId, 10)
+    const serviceType = Number.parseInt(serviceTypeId, 10)
+    if (Number.isNaN(provider) || Number.isNaN(serviceType)) {
+      return
+    }
+    const startDate = new Date(start)
+    const endDate = new Date(end)
+    if (
+      Number.isNaN(startDate.getTime()) ||
+      Number.isNaN(endDate.getTime()) ||
+      endDate <= startDate
+    ) {
+      return
+    }
+
+    const collision = activeAppointments.some(a => {
+      if (a.provider?.id !== provider) {
+        return false
+      }
+      const appointmentStart = new Date(a.start)
+      const appointmentEnd = new Date(a.end)
+      if (
+        Number.isNaN(appointmentStart.getTime()) ||
+        Number.isNaN(appointmentEnd.getTime())
+      ) {
+        return false
+      }
+      return appointmentStart < endDate && appointmentEnd > startDate
+    })
+
     if (collision) {
       return
     }
+
     dispatch(
       create({
-        providerId: parseInt(providerId, 10),
-        serviceTypeId: parseInt(serviceTypeId, 10),
-        start,
+        providerId: provider,
+        serviceTypeId: serviceType,
+        start: startDate.toISOString(),
+        end: endDate.toISOString(),
         notes,
         reminderOptIn: reminder,
       })
@@ -59,8 +135,11 @@ function AppointmentForm() {
     <form onSubmit={handleSubmit} className="p-4 space-y-4 bg-white">
       <h1 className="text-2xl">{t('appointments.new')}</h1>
       <div>
-        <label className="block mb-1">{t('appointments.provider')}</label>
+        <label className="block mb-1" htmlFor="appointment-provider">
+          {t('appointments.provider')}
+        </label>
         <select
+          id="appointment-provider"
           value={providerId}
           onChange={e => setProviderId(e.target.value)}
           className="border p-2 w-full"
@@ -74,8 +153,11 @@ function AppointmentForm() {
         </select>
       </div>
       <div>
-        <label className="block mb-1">{t('appointments.service_type')}</label>
+        <label className="block mb-1" htmlFor="appointment-service-type">
+          {t('appointments.service_type')}
+        </label>
         <select
+          id="appointment-service-type"
           value={serviceTypeId}
           onChange={e => setServiceTypeId(e.target.value)}
           className="border p-2 w-full"
@@ -89,23 +171,41 @@ function AppointmentForm() {
         </select>
       </div>
       <div>
-        <label className="block mb-1">{t('appointments.slot')}</label>
-        <select
+        <label className="block mb-1" htmlFor="appointment-start">
+          {t('appointments.slot')}
+        </label>
+        <input
+          id="appointment-start"
+          type="datetime-local"
           value={start}
-          onChange={e => setStart(e.target.value)}
+          onChange={e => {
+            setStart(e.target.value)
+            setUserEditedEnd(false)
+          }}
           className="border p-2 w-full"
-        >
-          <option value="">{t('appointments.slot')}</option>
-          {availableSlots.map(s => (
-            <option key={s.id} value={s.start}>
-              {new Date(s.start).toLocaleString()}
-            </option>
-          ))}
-        </select>
+        />
       </div>
       <div>
-        <label className="block mb-1">{t('appointments.notes')}</label>
+        <label className="block mb-1" htmlFor="appointment-end">
+          {t('appointments.end_time', { defaultValue: 'End time' })}
+        </label>
+        <input
+          id="appointment-end"
+          type="datetime-local"
+          value={end}
+          onChange={e => {
+            setEnd(e.target.value)
+            setUserEditedEnd(true)
+          }}
+          className="border p-2 w-full"
+        />
+      </div>
+      <div>
+        <label className="block mb-1" htmlFor="appointment-notes">
+          {t('appointments.notes')}
+        </label>
         <textarea
+          id="appointment-notes"
           value={notes}
           onChange={e => setNotes(e.target.value)}
           className="border p-2 w-full"

--- a/frontend/src/modules/appointments/AppointmentList.tsx
+++ b/frontend/src/modules/appointments/AppointmentList.tsx
@@ -29,11 +29,11 @@ function AppointmentList() {
           {appointments.map(a => (
             <tr key={a.id} className="text-center">
               <td className="border p-2">{new Date(a.start).toLocaleString()}</td>
-              <td className="border p-2">{a.provider.name}</td>
+              <td className="border p-2">{a.provider?.name ?? '-'}</td>
               <td className="border p-2">{a.serviceType.name}</td>
               <td className="border p-2">{a.status}</td>
               <td className="border p-2">
-                {a.status === 'confirmed' && (
+                {a.status === 'confirmed' && a.provider && (
                   <div className="font-semibold">
                     {t('appointment.confirmation.subject', {
                       providerName: a.provider.name,


### PR DESCRIPTION
## Summary
- load providers, service types, and appointments from the existing /api routes and map backend fields into the frontend appointment model
- update the appointment form, admin dashboard, and list views to work with nullable providers, mapped start/end fields, and manual scheduling instead of "available" slots
- refresh appointment tests to cover the new mapping and default end-time handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1a91436883248e7a6f40a528bc9e