### PR TITLE
Add invoice metadata endpoint and update client

### DIFF
--- a/frontend/src/modules/invoices/__tests__/InvoiceDetail.test.tsx
+++ b/frontend/src/modules/invoices/__tests__/InvoiceDetail.test.tsx
@@ -23,7 +23,7 @@ describe('InvoiceDetail', () => {
       createdAt: '2024-01-01T00:00:00Z',
       amount: '100',
       status: 'paid',
-      downloadUrl: '/one.pdf',
+      downloadUrl: '/api/invoices/1',
     }
 
     const store = {
@@ -39,7 +39,7 @@ describe('InvoiceDetail', () => {
     )
 
     fireEvent.click(screen.getByText('invoices.download'))
-    expect(open).toHaveBeenCalledWith('/one.pdf', '_blank')
+    expect(open).toHaveBeenCalledWith('/api/invoices/1', '_blank')
   })
 })
 

--- a/frontend/src/modules/invoices/invoiceSlice.test.ts
+++ b/frontend/src/modules/invoices/invoiceSlice.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import reducer, { fetchById } from './invoiceSlice'
+
+const getMock = vi.fn()
+
+vi.mock('../../axios', () => ({
+  default: {
+    get: (...args: unknown[]) => getMock(...args),
+  },
+}))
+
+describe('invoiceSlice', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+  })
+
+  it('fetchById loads metadata endpoint and sets current invoice', async () => {
+    const invoice = {
+      id: 5,
+      createdAt: '2024-05-01T12:00:00Z',
+      amount: '100.00',
+      status: 'paid',
+      downloadUrl: '/api/invoices/5',
+    }
+
+    getMock.mockResolvedValue({ data: invoice })
+
+    const dispatch = vi.fn()
+    const result = await fetchById(5)(dispatch, () => ({}), undefined)
+
+    expect(getMock).toHaveBeenCalledWith('/invoices/5/meta')
+    expect(result.payload).toEqual(invoice)
+
+    const state = reducer(undefined, fetchById.fulfilled(invoice, '', 5))
+    expect(state.current).toEqual(invoice)
+  })
+})

--- a/frontend/src/modules/invoices/invoiceSlice.ts
+++ b/frontend/src/modules/invoices/invoiceSlice.ts
@@ -24,7 +24,7 @@ export const fetchAll = createAsyncThunk('invoices/fetchAll', async () => {
 })
 
 export const fetchById = createAsyncThunk('invoices/fetchById', async (id: number) => {
-  const response = await api.get<Invoice>(`/invoices/${id}`)
+  const response = await api.get<Invoice>(`/invoices/${id}/meta`)
   return response.data
 })
 


### PR DESCRIPTION
## Summary
- add a dedicated /api/invoices/{id}/meta endpoint that shares access control with the PDF download
- cover the metadata response in backend tests
- update the invoice slice and component tests to consume the metadata endpoint and ensure the download button uses downloadUrl

## Testing
- php bin/phpunit
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cc221246848324be2f7b46bd4e1ae2