### PR TITLE
Use named volume for PostgreSQL data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .env
+db/
 backend/config/jwt/private.pem
 !backend/.env
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ To deploy with Docker Compose manually:
 - All Composer and NPM dependencies are installed automatically during the image build.
 - The frontend is served as an Nginx static server.
 
+### PostgreSQL data persistence
+
+PostgreSQL stores its data in the named Docker volume `db-data` declared in `docker-compose.yml`. The former `./db/data` bind
+mount is no longer used; remove any legacy `db/` directory after switching to the volume so stale files do not confuse local
+setups. Named volumes are managed by Docker and survive `docker compose down`, meaning database contents persist across
+redeployments. Only prune them intentionally—for example with `docker volume prune` or `docker volume rm db-data`—after
+creating a backup (e.g. via `pg_dump`) to avoid losing production data.
+
 The included `nginx-proxy` and `acme-companion` automatically request and renew TLS certificates via Let's Encrypt. Ensure the companion sees the proxy by exporting `NGINX_PROXY_CONTAINER=proxy` (as done in `docker-compose.yml`) or by giving the proxy container that name before starting the stack; otherwise certificate discovery fails. The proxy routes requests based on the path:
 
 - https://app.silent-oak-ranch.de → Frontend (Port 80)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:15
     env_file: .env
     volumes:
-      - ./db/data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     healthcheck:
       test:
         - CMD-SHELL
@@ -86,3 +86,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- switch the PostgreSQL container to a named volume and declare it in `docker-compose.yml`
- ignore any legacy `db/` directory that may linger on developer machines
- document the new persistence approach and cleanup considerations in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc2b712b0c8324927dc4033f68670f