### PR TITLE
Use secure JWT cookies for auth flows

### DIFF
--- a/backend/config/packages/lexik_jwt_authentication.yaml
+++ b/backend/config/packages/lexik_jwt_authentication.yaml
@@ -4,3 +4,11 @@ lexik_jwt_authentication:
     pass_phrase: '%env(JWT_PASSPHRASE)%'
     token_ttl: 3600
     user_id_claim: email
+    token_extractors:
+        authorization_header:
+            enabled: true
+            prefix: Bearer
+            name: Authorization
+        cookie:
+            enabled: true
+            name: 'sor_token'

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -30,6 +30,7 @@ security:
         - { path: ^/healthz, roles: PUBLIC_ACCESS }
         - { path: ^/api/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/register, roles: PUBLIC_ACCESS }
+        - { path: ^/api/logout, roles: PUBLIC_ACCESS }
         - { path: ^/api/invite, roles: ROLE_ADMIN }
         - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -9,12 +9,19 @@ export type RegisterPayload = {
   roles?: string[]
 }
 
-export async function register(payload: RegisterPayload) {
+export type AuthMetadata = {
+  role?: string | null
+  roles?: string[]
+  expiresAt?: string
+  expiresIn?: number
+}
+
+export async function register(payload: RegisterPayload): Promise<AuthMetadata> {
   const response = await api.post('/register', payload)
   return response.data
 }
 
-export async function login(email: string, password: string) {
+export async function login(email: string, password: string): Promise<AuthMetadata> {
   const response = await api.post('/login', { email, password })
   return response.data
 }
@@ -24,7 +31,7 @@ export async function inviteUser(email: string) {
   return response.data
 }
 
-export async function acceptInvite(token: string, password: string) {
+export async function acceptInvite(token: string, password: string): Promise<AuthMetadata> {
   const response = await api.post(`/accept-invite/${token}`, { password })
   return response.data
 }

--- a/frontend/src/axios.ts
+++ b/frontend/src/axios.ts
@@ -4,13 +4,6 @@ const api = axios.create({
   baseURL: '/api',
 })
 
-api.interceptors.request.use(config => {
-  const token = localStorage.getItem('token')
-  if (token) {
-    config.headers = config.headers ?? {}
-    config.headers.Authorization = `Bearer ${token}`
-  }
-  return config
-})
+api.defaults.withCredentials = true
 
 export default api

--- a/frontend/src/modules/auth/AuthContext.test.tsx
+++ b/frontend/src/modules/auth/AuthContext.test.tsx
@@ -21,19 +21,20 @@ function TestConsumer({ onReady }: { onReady: (value: AuthContextValue) => void 
   return null
 }
 
-describe('AuthContext login', () => {
+describe('AuthContext', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     postMock.mockReset()
     getMock.mockReset()
-    localStorage.clear()
+    postMock.mockResolvedValue({ data: {} })
+    getMock.mockRejectedValue({ response: { status: 401 } })
   })
 
   afterEach(() => {
     cleanup()
   })
 
-  it('stores token and provided role on successful login', async () => {
+  it('loads user info on successful login and resolves roles', async () => {
     const user: UserInfo = {
       id: 1,
       email: 'john@example.com',
@@ -42,11 +43,6 @@ describe('AuthContext login', () => {
       lastName: 'Doe',
     }
 
-    postMock.mockResolvedValue({
-      data: { token: 'jwt-token', role: 'customer', roles: ['ROLE_CUSTOMER'] },
-    })
-    getMock.mockResolvedValue({ data: user })
-
     let contextValue: AuthContextValue | undefined
 
     render(
@@ -55,9 +51,14 @@ describe('AuthContext login', () => {
       </AuthProvider>
     )
 
+    await waitFor(() => expect(contextValue?.initialized).toBe(true))
+
     if (!contextValue) {
       throw new Error('Auth context not ready')
     }
+
+    postMock.mockResolvedValueOnce({ data: { role: 'customer', roles: ['ROLE_CUSTOMER'] } })
+    getMock.mockResolvedValueOnce({ data: user })
 
     await act(async () => {
       await contextValue!.login('john@example.com', 'secret123')
@@ -65,31 +66,23 @@ describe('AuthContext login', () => {
 
     await waitFor(() => {
       expect(contextValue?.role).toBe('customer')
+      expect(contextValue?.user).toEqual(user)
+      expect(contextValue?.isAuthenticated).toBe(true)
     })
 
     expect(postMock).toHaveBeenCalledWith('/login', {
       email: 'john@example.com',
       password: 'secret123',
     })
-    expect(getMock).toHaveBeenCalledWith('/me', {
-      headers: { Authorization: 'Bearer jwt-token' },
-    })
-    expect(localStorage.getItem('token')).toBe('jwt-token')
-    expect(localStorage.getItem('role')).toBe('customer')
-    expect(JSON.parse(localStorage.getItem('user') ?? 'null')).toEqual(user)
+    expect(getMock).toHaveBeenCalledWith('/me')
   })
 
-  it('falls back to role information from /me when not returned from login', async () => {
+  it('falls back to /me roles when not returned from login metadata', async () => {
     const user: UserInfo = {
       id: 2,
       email: 'admin@example.com',
       roles: ['ROLE_ADMIN'],
     }
-
-    postMock.mockResolvedValue({
-      data: { token: 'other-token' },
-    })
-    getMock.mockResolvedValue({ data: user })
 
     let contextValue: AuthContextValue | undefined
 
@@ -99,9 +92,14 @@ describe('AuthContext login', () => {
       </AuthProvider>
     )
 
+    await waitFor(() => expect(contextValue?.initialized).toBe(true))
+
     if (!contextValue) {
       throw new Error('Auth context not ready')
     }
+
+    postMock.mockResolvedValueOnce({ data: {} })
+    getMock.mockResolvedValueOnce({ data: user })
 
     await act(async () => {
       await contextValue!.login('admin@example.com', 'secret123')
@@ -110,8 +108,47 @@ describe('AuthContext login', () => {
     await waitFor(() => {
       expect(contextValue?.role).toBe('admin')
     })
+  })
 
-    expect(localStorage.getItem('role')).toBe('admin')
-    expect(localStorage.getItem('role')).not.toBe('ROLE_ADMIN')
+  it('calls logout endpoint and clears user state', async () => {
+    const user: UserInfo = {
+      id: 3,
+      email: 'user@example.com',
+      roles: ['ROLE_CUSTOMER'],
+    }
+
+    let contextValue: AuthContextValue | undefined
+
+    render(
+      <AuthProvider>
+        <TestConsumer onReady={value => (contextValue = value)} />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(contextValue?.initialized).toBe(true))
+
+    if (!contextValue) {
+      throw new Error('Auth context not ready')
+    }
+
+    postMock.mockResolvedValueOnce({ data: { role: 'customer' } })
+    getMock.mockResolvedValueOnce({ data: user })
+
+    await act(async () => {
+      await contextValue!.login('user@example.com', 'secret123')
+    })
+
+    await waitFor(() => expect(contextValue?.isAuthenticated).toBe(true))
+
+    postMock.mockResolvedValueOnce({ data: { message: 'Logged out' } })
+
+    await act(async () => {
+      await contextValue!.logout()
+    })
+
+    expect(postMock).toHaveBeenLastCalledWith('/logout')
+    expect(contextValue?.user).toBeNull()
+    expect(contextValue?.isAuthenticated).toBe(false)
+    expect(contextValue?.role).toBeNull()
   })
 })

--- a/frontend/src/modules/auth/AuthGuard.tsx
+++ b/frontend/src/modules/auth/AuthGuard.tsx
@@ -3,8 +3,11 @@ import { Navigate } from 'react-router-dom'
 import { useAuth } from './AuthContext'
 
 export default function AuthGuard({ children, role }: { children: ReactElement; role?: 'admin' | 'staff' | 'customer' }) {
-  const { token, role: currentRole } = useAuth()
-  if (!token || (role && currentRole !== role)) {
+  const { isAuthenticated, role: currentRole, isLoading } = useAuth()
+  if (isLoading) {
+    return null
+  }
+  if (!isAuthenticated || (role && currentRole !== role)) {
     return <Navigate to="/login" replace />
   }
   return children

--- a/frontend/src/modules/auth/AuthSlice.test.ts
+++ b/frontend/src/modules/auth/AuthSlice.test.ts
@@ -1,25 +1,22 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import reducer, { setToken, logout } from './authSlice'
+import { describe, it, expect } from 'vitest'
+import reducer, { setAuthenticated, logout } from './authSlice'
 
 describe('authSlice reducers', () => {
-  beforeEach(() => {
-    localStorage.clear()
-  })
-
-  it('setToken stores token and marks user as logged in', () => {
-    const initial = { token: null, isLoggedIn: false }
-    const state = reducer(initial, setToken('abc123'))
-    expect(state.token).toBe('abc123')
+  it('setAuthenticated marks user as logged in by default', () => {
+    const initial = { isLoggedIn: false }
+    const state = reducer(initial, setAuthenticated())
     expect(state.isLoggedIn).toBe(true)
-    expect(localStorage.getItem('token')).toBe('abc123')
   })
 
-  it('logout clears token and marks user as logged out', () => {
-    localStorage.setItem('token', 'abc123')
-    const initial = { token: 'abc123', isLoggedIn: true }
-    const state = reducer(initial, logout())
-    expect(state.token).toBeNull()
+  it('setAuthenticated respects explicit payload', () => {
+    const initial = { isLoggedIn: true }
+    const state = reducer(initial, setAuthenticated(false))
     expect(state.isLoggedIn).toBe(false)
-    expect(localStorage.getItem('token')).toBeNull()
+  })
+
+  it('logout marks user as logged out', () => {
+    const initial = { isLoggedIn: true }
+    const state = reducer(initial, logout())
+    expect(state.isLoggedIn).toBe(false)
   })
 })

--- a/frontend/src/modules/auth/PrivateRoute.tsx
+++ b/frontend/src/modules/auth/PrivateRoute.tsx
@@ -6,9 +6,13 @@ interface PrivateRouteProps {
 }
 
 export default function PrivateRoute({ roles }: PrivateRouteProps) {
-  const { token, role } = useAuth()
+  const { isAuthenticated, role, isLoading } = useAuth()
 
-  if (!token) {
+  if (isLoading) {
+    return null
+  }
+
+  if (!isAuthenticated) {
     return <Navigate to="/login" replace />
   }
 

--- a/frontend/src/modules/auth/authSlice.ts
+++ b/frontend/src/modules/auth/authSlice.ts
@@ -1,31 +1,25 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 interface AuthState {
-  token: string | null
   isLoggedIn: boolean
 }
 
 const initialState: AuthState = {
-  token: localStorage.getItem('token'),
-  isLoggedIn: !!localStorage.getItem('token'),
+  isLoggedIn: false,
 }
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setToken(state, action: PayloadAction<string>) {
-      state.token = action.payload
-      state.isLoggedIn = true
-      localStorage.setItem('token', action.payload)
+    setAuthenticated(state, action: PayloadAction<boolean | undefined>) {
+      state.isLoggedIn = action.payload ?? true
     },
     logout(state) {
-      state.token = null
       state.isLoggedIn = false
-      localStorage.removeItem('token')
     },
   },
 })
 
-export const { setToken, logout } = authSlice.actions
+export const { setAuthenticated, logout } = authSlice.actions
 export default authSlice.reducer

--- a/frontend/src/modules/auth/useUser.ts
+++ b/frontend/src/modules/auth/useUser.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import api from '../../axios'
-import { useAuth } from './AuthContext'
 import { useTranslation } from 'react-i18next'
+import { useAuth } from './AuthContext'
 
 export type UserInfo = {
   id: number
@@ -16,31 +15,20 @@ export type UserInfo = {
 }
 
 export function useUser() {
-  const { token } = useAuth()
-  const [user, setUser] = useState<UserInfo | null>(null)
-  const [loading, setLoading] = useState(false)
+  const { user, isLoading, error: authError } = useAuth()
   const [error, setError] = useState<string | null>(null)
   const { t } = useTranslation()
 
   useEffect(() => {
-    if (!token) {
-      setUser(null)
-      setLoading(false)
+    if (!authError) {
+      setError(null)
       return
     }
-    setLoading(true)
-    setError(null)
-    api
-      .get('/me', { headers: { Authorization: `Bearer ${token}` } })
-      .then(res => setUser(res.data as UserInfo))
-      .catch(() => {
-        setUser(null)
-        setError(t('auth.user_error'))
-      })
-      .finally(() => setLoading(false))
-  }, [token])
 
-  return { user, loading, error }
+    setError(t('auth.user_error'))
+  }, [authError, t])
+
+  return { user, loading: isLoading, error }
 }
 
 export default useUser

--- a/frontend/src/modules/dashboard/Dashboard.tsx
+++ b/frontend/src/modules/dashboard/Dashboard.tsx
@@ -1,9 +1,10 @@
-import { logout } from '../auth/authSlice'
+import { logout as logoutAction } from '../auth/authSlice'
 import { useAppDispatch } from '../../store'
 import { useTranslation } from 'react-i18next'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import api from '../../axios'
+import { useAuth } from '../auth/AuthContext'
 
 interface Horse {
   id: number
@@ -28,6 +29,7 @@ interface Invoice {
 function Dashboard() {
   const dispatch = useAppDispatch()
   const { t } = useTranslation()
+  const { logout } = useAuth()
   const [horses, setHorses] = useState<Horse[]>([])
   const [bookings, setBookings] = useState<Booking[]>([])
   const [invoices, setInvoices] = useState<Invoice[]>([])
@@ -38,8 +40,12 @@ function Dashboard() {
     api.get('/my/invoices').then(res => setInvoices(res.data))
   }, [])
 
-  function handleLogout() {
-    dispatch(logout())
+  async function handleLogout() {
+    try {
+      await logout()
+    } finally {
+      dispatch(logoutAction())
+    }
   }
 
   return (

--- a/frontend/src/pages/InviteAccept.tsx
+++ b/frontend/src/pages/InviteAccept.tsx
@@ -2,14 +2,16 @@ import { useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { acceptInvite } from '../api/auth'
 import { useAppDispatch } from '../store'
-import { setToken } from '../modules/auth/authSlice'
+import { setAuthenticated } from '../modules/auth/authSlice'
 import { useTranslation } from 'react-i18next'
+import { useAuth } from '../modules/auth/AuthContext'
 
 function InviteAccept() {
   const [searchParams] = useSearchParams()
   const inviteToken = searchParams.get('token') || ''
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
+  const { refresh } = useAuth()
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const { t } = useTranslation()
@@ -18,7 +20,8 @@ function InviteAccept() {
     e.preventDefault()
     try {
       const data = await acceptInvite(inviteToken, password)
-      dispatch(setToken(data.token))
+      await refresh({ role: data.role, roles: data.roles })
+      dispatch(setAuthenticated(true))
       navigate('/dashboard')
     } catch (err) {
       setError(t('auth.invite.error'))

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { login } from '../api/auth'
+import { login as loginRequest } from '../api/auth'
 import { useAppDispatch } from '../store'
-import { setToken } from '../modules/auth/authSlice'
+import { setAuthenticated } from '../modules/auth/authSlice'
 import { useTranslation } from 'react-i18next'
+import { useAuth } from '../modules/auth/AuthContext'
 
 function Login() {
   const dispatch = useAppDispatch()
+  const { refresh } = useAuth()
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -16,8 +18,9 @@ function Login() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     try {
-      const data = await login(email, password)
-      dispatch(setToken(data.token))
+      const data = await loginRequest(email, password)
+      await refresh({ role: data.role, roles: data.roles })
+      dispatch(setAuthenticated(true))
       navigate('/dashboard')
     } catch (err) {
       setError(t('auth.login.error'))


### PR DESCRIPTION
## Summary
- enable the Lexik JWT cookie extractor alongside Authorization headers
- issue secure HttpOnly `sor_token` cookies on auth responses, expose logout, and cover them in PHPUnit tests
- switch the frontend auth flow to rely on cookies, remove localStorage usage, and update tests

## Testing
- DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db" vendor/bin/phpunit
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2c9838988324b5258013f666c38d