### PR TITLE
Add validation for contact form submissions

### DIFF
--- a/backend/src/Controller/ContactController.php
+++ b/backend/src/Controller/ContactController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Controller;
+
+use App\Message\ContactSubmission;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ContactController extends AbstractController
+{
+    public function __construct(private readonly MessageBusInterface $bus)
+    {
+    }
+
+    #[Route('/api/contact', name: 'api_contact_submit', methods: ['POST'])]
+    public function submit(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+        if (!is_array($payload)) {
+            return $this->json(['message' => 'Invalid payload'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $name = isset($payload['name']) && is_string($payload['name']) ? trim($payload['name']) : null;
+        $rawEmail = isset($payload['email']) && is_string($payload['email']) ? trim($payload['email']) : null;
+        $message = isset($payload['message']) && is_string($payload['message']) ? trim($payload['message']) : null;
+
+        if ($name === null || $name === '' || $rawEmail === null || $rawEmail === '' || $message === null || $message === '') {
+            return $this->json(['message' => 'Invalid payload'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $email = filter_var($rawEmail, FILTER_VALIDATE_EMAIL);
+        if ($email === false) {
+            return $this->json(['message' => 'Invalid payload'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $submission = new ContactSubmission($name, $email, $message);
+        $this->bus->dispatch($submission);
+
+        return $this->json(['message' => 'Message sent']);
+    }
+}

--- a/backend/src/Message/ContactSubmission.php
+++ b/backend/src/Message/ContactSubmission.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Message;
+
+class ContactSubmission
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly string $email,
+        private readonly string $message,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
## Summary
- add a contact controller that validates incoming contact payloads
- ensure name, email, and message strings are trimmed and validated before dispatching a ContactSubmission message
- introduce a ContactSubmission message DTO to carry sanitized contact details

## Testing
- php -l backend/src/Controller/ContactController.php
- php -l backend/src/Message/ContactSubmission.php

------
https://chatgpt.com/codex/tasks/task_e_68da89ea8400832496bad4418bccc712